### PR TITLE
Update deprecated dialog background color

### DIFF
--- a/lib/page_creator/assets/baader.dart
+++ b/lib/page_creator/assets/baader.dart
@@ -64,7 +64,7 @@ class Baader221Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(

--- a/lib/page_creator/assets/beckhoff.dart
+++ b/lib/page_creator/assets/beckhoff.dart
@@ -566,7 +566,7 @@ class BeckhoffEL1008Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(
@@ -705,7 +705,7 @@ class BeckhoffEL2008Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(
@@ -937,7 +937,7 @@ class BeckhoffEL9222Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(
@@ -1060,7 +1060,7 @@ class BeckhoffEL9187Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(
@@ -1165,7 +1165,7 @@ class BeckhoffEL9186Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(
@@ -1743,7 +1743,7 @@ class BeckhoffEL3054Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(

--- a/lib/page_creator/assets/button.dart
+++ b/lib/page_creator/assets/button.dart
@@ -68,7 +68,7 @@ class ButtonConfig extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(

--- a/lib/page_creator/assets/option_variable.dart
+++ b/lib/page_creator/assets/option_variable.dart
@@ -80,7 +80,7 @@ class OptionVariableConfig extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(

--- a/lib/page_creator/assets/schneider.dart
+++ b/lib/page_creator/assets/schneider.dart
@@ -49,7 +49,7 @@ class SchneiderATV320Config extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(

--- a/lib/page_creator/assets/text.dart
+++ b/lib/page_creator/assets/text.dart
@@ -66,7 +66,7 @@ class TextAssetConfig extends BaseAsset {
         ),
         child: Material(
           borderRadius: BorderRadius.circular(24),
-          color: Theme.of(context).dialogBackgroundColor,
+          color: DialogTheme.of(context).backgroundColor ?? Theme.of(context).colorScheme.surface,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: SingleChildScrollView(


### PR DESCRIPTION
Replace deprecated `dialogBackgroundColor` with `DialogTheme.of(context).backgroundColor` to resolve deprecation warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-dff0a68c-8222-4e42-945b-a2f7bdcd3eda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dff0a68c-8222-4e42-945b-a2f7bdcd3eda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

