### PR TITLE
fix: umas stub Python detection + retry queue overflow

### DIFF
--- a/packages/tfc_dart/lib/core/database.dart
+++ b/packages/tfc_dart/lib/core/database.dart
@@ -211,7 +211,16 @@ class _PendingWrite {
   final DateTime time;
   final dynamic value;
 
-  _PendingWrite(this.time, this.value);
+  /// Monotonic sequence number for deterministic insertion-order sorting.
+  /// [DateTime.now()] has limited resolution on Windows (~15 ms), so many
+  /// writes created in a tight loop share the same timestamp.  Sorting by
+  /// [time] alone gives a non-deterministic order for equal timestamps
+  /// (Dart's [List.sort] is not guaranteed stable), which causes the wrong
+  /// items to be dropped during queue overflow trimming.
+  final int seq;
+  static int _nextSeq = 0;
+
+  _PendingWrite(this.time, this.value) : seq = _nextSeq++;
 
   Map<String, dynamic> toMap() {
     if (value is Map<String, dynamic>) {
@@ -640,12 +649,14 @@ class Database {
   ///
   /// When multiple concurrent flushes fail, the order they call this method is
   /// non-deterministic. To always drop the globally oldest data regardless of
-  /// call order, items are sorted by timestamp before trimming.
+  /// call order, items are sorted by monotonic sequence number before trimming.
+  /// (Sorting by timestamp alone is non-deterministic on Windows where
+  /// DateTime.now() has ~15 ms resolution and Dart's List.sort is not stable.)
   void _queueForRetry(String tableName, List<_PendingWrite> writes) {
     final queue = _retryQueue.putIfAbsent(tableName, () => []);
     queue.addAll(writes);
     if (queue.length > _maxRetryQueueSize) {
-      queue.sort((a, b) => a.time.compareTo(b.time));
+      queue.sort((a, b) => a.seq.compareTo(b.seq));
       final overflow = queue.length - _maxRetryQueueSize;
       logger.w('Retry queue overflow for $tableName, dropping $overflow oldest items');
       queue.removeRange(0, overflow);

--- a/packages/tfc_dart/test/subscription_inactivity_test.dart
+++ b/packages/tfc_dart/test/subscription_inactivity_test.dart
@@ -324,12 +324,22 @@ void main() {
     await client.connect("opc.tcp://127.0.0.1:$serverPort");
 
     try {
-      // Very short-lived subscription (same as test B)
-      final subId = await client.subscriptionCreate(
-        requestedPublishingInterval: Duration(milliseconds: 10),
-        requestedLifetimeCount: 3,
-        requestedMaxKeepAliveCount: 1,
-      );
+      // Retry subscription creation — on Windows CI the previous test's
+      // server socket may linger briefly, causing BadSessionClosed.
+      late int subId;
+      for (var attempt = 0; attempt < 5; attempt++) {
+        try {
+          subId = await client.subscriptionCreate(
+            requestedPublishingInterval: Duration(milliseconds: 10),
+            requestedLifetimeCount: 3,
+            requestedMaxKeepAliveCount: 1,
+          );
+          break;
+        } catch (e) {
+          if (attempt == 4) rethrow;
+          await Future.delayed(Duration(milliseconds: 200));
+        }
+      }
 
       // Wire up ClientWrapper with the real client and start heartbeat
       final config = OpcUAConfig()

--- a/packages/tfc_dart/test/umas_e2e_test.dart
+++ b/packages/tfc_dart/test/umas_e2e_test.dart
@@ -39,8 +39,16 @@ Process? _serverProcess;
 final _portPattern = RegExp(r'PORT=(\d+)');
 
 Future<void> _startStub() async {
-  final python = Platform.isWindows ? 'python' : 'python3';
   final stubScript = '$_projectRoot/test/umas_stub_server.py';
+
+  // Try python3 first (Unix, some Windows setups), fall back to python.
+  String python;
+  try {
+    final r = await Process.run('python3', ['--version']);
+    python = r.exitCode == 0 ? 'python3' : 'python';
+  } catch (_) {
+    python = 'python';
+  }
 
   // Use port 0 so the OS assigns a free port — no cleanup needed.
   _serverProcess = await Process.start(
@@ -49,9 +57,13 @@ Future<void> _startStub() async {
   );
 
   // Collect stderr for debugging
+  final stderrBuf = StringBuffer();
   _serverProcess!.stderr
       .transform(const SystemEncoding().decoder)
-      .listen((line) => stderr.write('[STUB ERR] $line'));
+      .listen((line) {
+    stderr.write('[STUB ERR] $line');
+    stderrBuf.write(line);
+  });
 
   // Wait for the stub to print its actual port.
   final completer = Completer<int>();
@@ -68,7 +80,9 @@ Future<void> _startStub() async {
   });
 
   _stubPort = await completer.future.timeout(const Duration(seconds: 5),
-      onTimeout: () => throw StateError('Stub server did not start'));
+      onTimeout: () => throw StateError(
+          'Stub server did not start (python=$python, '
+          'script=$stubScript, stderr=$stderrBuf)'));
 }
 
 void _stopStub() {


### PR DESCRIPTION
## Summary

Two fixes for flaky Windows CI:

1. **umas_e2e_test**: Try `python3` before `python` — Windows CI runners may only have `python3` in PATH. Add detailed error message (python path, script path, stderr) when stub fails to start.

2. **database.dart**: Use monotonic sequence number for retry queue overflow trimming instead of `DateTime` (which has ~15ms resolution on Windows, causing non-deterministic sort).

3. **subscription_inactivity_test D**: Add subscription creation retry (same pattern as test C) for `BadSessionClosed` on Windows.

## Test plan

- [ ] CI: tfc-dart-test passes on Windows
- [ ] CI: umas_e2e_test stub starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)