### PR TITLE
ci: pin Flutter SDK to 3.41.9 (font_awesome_flutter IconData regression)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.41.9'
 
       - name: Get Flutter packages
         working-directory: centroid-hmi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: subosito/flutter-action@v2
       with:
-        channel: stable
+        flutter-version: '3.41.9'
 
     - name: Install native dependencies (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          flutter-version: '3.41.9'
 
       - name: Get Flutter packages
         working-directory: centroid-hmi


### PR DESCRIPTION
## Summary
- Pin `subosito/flutter-action@v2` to `flutter-version: '3.41.9'` in `test.yml`, `macos.yml`, `windows.yml`. Previously these used `channel: stable` (unpinned), which silently absorbed a recent Flutter SDK breaking change.

## Why this is needed
Flutter stable released a build where `IconData` is now a `final class`. Every published `font_awesome_flutter` version (10.8.0 / 10.9.1 / 10.12.0) subclasses `IconData` to provide `IconDataBrands` / `IconDataSolid` / etc. — so the package itself no longer compiles against the new SDK. CI on PR #122 surfaced this as:

```
font_awesome_flutter-10.12.0/lib/src/icon_data.dart:6:30:
Error: The class 'IconData' can't be extended outside of its library because it's a final class.
```

The `tfc_dart` and `modbus_lib` jobs pass — only `flutter-test` and `build` fail, and only because of the package compile error above.

## Why pin Flutter SDK (not font_awesome_flutter)
- There is **no version** of font_awesome_flutter that compiles against the current Flutter stable — they all subclass IconData.
- Local developer Flutter is **3.41.9** (2026-04-29 stable, `flutter --version` confirms), and font_awesome_flutter 10.12.0 compiles cleanly there.
- Pinning the Flutter SDK in CI restores green CI immediately and aligns CI with what developers build against — best practice independent of this incident.

## When can the pin be lifted
Once font_awesome_flutter upstream switches from subclassing `IconData` to composition (or finds another path forward), the pin can be relaxed back to a `stable` channel — ideally with a `flutter-version` floor instead of pure `channel`.

## Test plan
- [ ] CI green on this PR across all three platforms (macOS / Ubuntu / Windows)
- [ ] After merge: rebase PR #122 onto main and confirm its `flutter-test` + `build` checks go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)