### PR TITLE
ci: bump Flutter to 3.44.9, migrate font_awesome_flutter to 11.0.0

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.9'
+          flutter-version: '3.44.9'
 
       - name: Get Flutter packages
         working-directory: centroid-hmi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.41.9'
+        flutter-version: '3.44.9'
 
     - name: Install native dependencies (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.9'
+          flutter-version: '3.44.9'
 
       - name: Get Flutter packages
         working-directory: centroid-hmi

--- a/centroid-hmi/lib/main.dart
+++ b/centroid-hmi/lib/main.dart
@@ -196,8 +196,8 @@ Future<void> _startApp([bool debugMode = false]) async {
         if (environmentVariableIsGod)
           MenuItem(label: 'Alarm Editor', path: '/advanced/alarm-editor', icon: Icons.alarm),
         MenuItem(label: 'History View', path: '/advanced/history-view', icon: Icons.history),
-        MenuItem(label: 'Server Config', path: '/advanced/server-config', icon: FontAwesomeIcons.server),
-        MenuItem(label: 'Key Repository', path: '/advanced/key-repository', icon: FontAwesomeIcons.key),
+        MenuItem(label: 'Server Config', path: '/advanced/server-config', icon: FontAwesomeIcons.server.data),
+        MenuItem(label: 'Key Repository', path: '/advanced/key-repository', icon: FontAwesomeIcons.key.data),
         MenuItem(label: 'Knowledge Base', path: '/advanced/knowledge-base', icon: Icons.library_books),
       ],
     ),

--- a/centroid-hmi/macos/Podfile.lock
+++ b/centroid-hmi/macos/Podfile.lock
@@ -1,105 +1,21 @@
 PODS:
-  - cryptography_flutter (0.0.1):
-    - FlutterMacOS
-  - desktop_drop (0.0.1):
-    - FlutterMacOS
-  - device_info_plus (0.0.1):
-    - FlutterMacOS
-  - file_picker (0.0.1):
-    - FlutterMacOS
   - flutter_secure_storage_macos (6.1.3):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - pdfium_flutter (0.1.5):
-    - Flutter
-    - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - sqlite3 (3.51.1):
-    - sqlite3/common (= 3.51.1)
-  - sqlite3/common (3.51.1)
-  - sqlite3/dbstatvtab (3.51.1):
-    - sqlite3/common
-  - sqlite3/fts5 (3.51.1):
-    - sqlite3/common
-  - sqlite3/math (3.51.1):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.51.1):
-    - sqlite3/common
-  - sqlite3/rtree (3.51.1):
-    - sqlite3/common
-  - sqlite3/session (3.51.1):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.51.1)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - cryptography_flutter (from `Flutter/ephemeral/.symlinks/plugins/cryptography_flutter/macos`)
-  - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
-  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - pdfium_flutter (from `Flutter/ephemeral/.symlinks/plugins/pdfium_flutter/darwin`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-
-SPEC REPOS:
-  trunk:
-    - sqlite3
 
 EXTERNAL SOURCES:
-  cryptography_flutter:
-    :path: Flutter/ephemeral/.symlinks/plugins/cryptography_flutter/macos
-  desktop_drop:
-    :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
-  device_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   flutter_secure_storage_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  pdfium_flutter:
-    :path: Flutter/ephemeral/.symlinks/plugins/pdfium_flutter/darwin
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  sqlite3_flutter_libs:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  cryptography_flutter: be2b3e0e31603521b6a1c2bea232a88a2488a91c
-  desktop_drop: 10a3e6a7fa9dbe350541f2574092fecfa345a07b
-  device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
-  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  pdfium_flutter: 512bc19dbbd80b4287d04869aa19ad729289079d
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
-  sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41
-  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/centroid-hmi/macos/Runner.xcodeproj/project.pbxproj
+++ b/centroid-hmi/macos/Runner.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		A1B2C3D4E5F60718293A4B5C /* NativeCursorPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* NativeCursorPlugin.swift */; };
 		791BE08BBB7D9401487888D2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57853F7EFC45408806A1F4E6 /* Pods_Runner.framework */; };
 		97E983CBA6E9A331EB3C531B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B8326A8D1BC2AFE842AF197 /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		BD4342002AE7CDB2E67CE1A9 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F4BBF3188889019FD4518D5F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				791BE08BBB7D9401487888D2 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -166,6 +169,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -233,6 +237,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -258,6 +265,9 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -805,6 +815,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/centroid-hmi/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/centroid-hmi/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simolus3/CSQLite.git",
+      "state" : {
+        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/centroid-hmi/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/centroid-hmi/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "CentroidX.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/centroid-hmi/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/centroid-hmi/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "csqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simolus3/CSQLite.git",
+      "state" : {
+        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/centroid-hmi/pubspec.lock
+++ b/centroid-hmi/pubspec.lock
@@ -581,10 +581,10 @@ packages:
     dependency: transitive
     description:
       name: font_awesome_flutter
-      sha256: b9011df3a1fa02993630b8fb83526368cf2206a711259830325bab2f1d2a4eb0
+      sha256: "09dcde8ab90ffae1a7d65ff2ef96fc62a17ad9d0ce7c127b317ded676b0d5935"
       url: "https://pub.dev"
     source: hosted
-    version: "10.12.0"
+    version: "11.0.0"
   get_it:
     dependency: transitive
     description:
@@ -796,10 +796,10 @@ packages:
     dependency: transitive
     description:
       name: mcp_dart
-      sha256: "30ab03147fec3fd72e98172475cd720cd4e3aec7d5f8944ef36dbfabc75a353c"
+      sha256: cfa44551f14610e2b58dc899098a0835ac77248ac55ce0dbc982a1a73aec307d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.0"
   meta:
     dependency: transitive
     description:

--- a/lib/converter/icon.dart
+++ b/lib/converter/icon.dart
@@ -657,169 +657,169 @@ class IconDataConverter implements JsonConverter<IconData, String> {
 
       // FontAwesome Icons
       case 'weight_scale':
-        return FontAwesomeIcons.weightScale;
+        return FontAwesomeIcons.weightScale.data;
       case 'scale_balanced':
-        return FontAwesomeIcons.scaleBalanced;
+        return FontAwesomeIcons.scaleBalanced.data;
       case 'weight_hanging':
-        return FontAwesomeIcons.weightHanging;
+        return FontAwesomeIcons.weightHanging.data;
       case 'bullseye':
-        return FontAwesomeIcons.bullseye;
+        return FontAwesomeIcons.bullseye.data;
       case 'ruler':
-        return FontAwesomeIcons.ruler;
+        return FontAwesomeIcons.ruler.data;
       case 'anchor':
-        return FontAwesomeIcons.anchor;
+        return FontAwesomeIcons.anchor.data;
       case 'magnifying_glass_location':
-        return FontAwesomeIcons.magnifyingGlassLocation;
+        return FontAwesomeIcons.magnifyingGlassLocation.data;
       case 'slash':
-        return FontAwesomeIcons.slash;
+        return FontAwesomeIcons.slash.data;
       case 'dumbbell':
-        return FontAwesomeIcons.dumbbell;
+        return FontAwesomeIcons.dumbbell.data;
       case 'play':
-        return FontAwesomeIcons.play;
+        return FontAwesomeIcons.play.data;
       case 'pause_fa':
-        return FontAwesomeIcons.pause;
+        return FontAwesomeIcons.pause.data;
       case 'stop_fa':
-        return FontAwesomeIcons.stop;
+        return FontAwesomeIcons.stop.data;
       case 'car':
-        return FontAwesomeIcons.car;
+        return FontAwesomeIcons.car.data;
       case 'droplet':
-        return FontAwesomeIcons.droplet;
+        return FontAwesomeIcons.droplet.data;
 
       // Additional commonly used FontAwesome icons
       case 'heart':
-        return FontAwesomeIcons.heart;
+        return FontAwesomeIcons.heart.data;
       case 'heart_solid':
-        return FontAwesomeIcons.solidHeart;
+        return FontAwesomeIcons.solidHeart.data;
       case 'user':
-        return FontAwesomeIcons.user;
+        return FontAwesomeIcons.user.data;
       case 'user_solid':
-        return FontAwesomeIcons.solidUser;
+        return FontAwesomeIcons.solidUser.data;
       case 'envelope':
-        return FontAwesomeIcons.envelope;
+        return FontAwesomeIcons.envelope.data;
       case 'envelope_solid':
-        return FontAwesomeIcons.solidEnvelope;
+        return FontAwesomeIcons.solidEnvelope.data;
       case 'fa_phone':
-        return FontAwesomeIcons.phone;
+        return FontAwesomeIcons.phone.data;
       case 'calendar':
-        return FontAwesomeIcons.calendar;
+        return FontAwesomeIcons.calendar.data;
       case 'calendar_solid':
-        return FontAwesomeIcons.solidCalendar;
+        return FontAwesomeIcons.solidCalendar.data;
       case 'clock':
-        return FontAwesomeIcons.clock;
+        return FontAwesomeIcons.clock.data;
       case 'clock_solid':
-        return FontAwesomeIcons.solidClock;
+        return FontAwesomeIcons.solidClock.data;
       case 'map_marker':
-        return FontAwesomeIcons.locationDot;
+        return FontAwesomeIcons.locationDot.data;
       case 'globe':
-        return FontAwesomeIcons.globe;
+        return FontAwesomeIcons.globe.data;
       case 'cog':
-        return FontAwesomeIcons.gear;
+        return FontAwesomeIcons.gear.data;
       case 'bars':
-        return FontAwesomeIcons.bars;
+        return FontAwesomeIcons.bars.data;
       case 'times':
-        return FontAwesomeIcons.xmark;
+        return FontAwesomeIcons.xmark.data;
       case 'check':
-        return FontAwesomeIcons.check;
+        return FontAwesomeIcons.check.data;
       case 'plus':
-        return FontAwesomeIcons.plus;
+        return FontAwesomeIcons.plus.data;
       case 'minus':
-        return FontAwesomeIcons.minus;
+        return FontAwesomeIcons.minus.data;
       case 'search':
-        return FontAwesomeIcons.magnifyingGlass;
+        return FontAwesomeIcons.magnifyingGlass.data;
       case 'edit':
-        return FontAwesomeIcons.penToSquare;
+        return FontAwesomeIcons.penToSquare.data;
       case 'trash':
-        return FontAwesomeIcons.trash;
+        return FontAwesomeIcons.trash.data;
       case 'download':
-        return FontAwesomeIcons.download;
+        return FontAwesomeIcons.download.data;
       case 'upload':
-        return FontAwesomeIcons.upload;
+        return FontAwesomeIcons.upload.data;
       case 'share':
-        return FontAwesomeIcons.share;
+        return FontAwesomeIcons.share.data;
       case 'eye':
-        return FontAwesomeIcons.eye;
+        return FontAwesomeIcons.eye.data;
       case 'eye_slash':
-        return FontAwesomeIcons.eyeSlash;
+        return FontAwesomeIcons.eyeSlash.data;
       case 'lock':
-        return FontAwesomeIcons.lock;
+        return FontAwesomeIcons.lock.data;
       case 'unlock':
-        return FontAwesomeIcons.unlock;
+        return FontAwesomeIcons.unlock.data;
       case 'key':
-        return FontAwesomeIcons.key;
+        return FontAwesomeIcons.key.data;
       case 'shield_alt':
-        return FontAwesomeIcons.shieldHalved;
+        return FontAwesomeIcons.shieldHalved.data;
       case 'star':
-        return FontAwesomeIcons.star;
+        return FontAwesomeIcons.star.data;
       case 'star_solid':
-        return FontAwesomeIcons.solidStar;
+        return FontAwesomeIcons.solidStar.data;
       case 'thumbs_up':
-        return FontAwesomeIcons.thumbsUp;
+        return FontAwesomeIcons.thumbsUp.data;
       case 'thumbs_down':
-        return FontAwesomeIcons.thumbsDown;
+        return FontAwesomeIcons.thumbsDown.data;
       case 'comment':
-        return FontAwesomeIcons.comment;
+        return FontAwesomeIcons.comment.data;
       case 'comment_solid':
-        return FontAwesomeIcons.solidComment;
+        return FontAwesomeIcons.solidComment.data;
       case 'bell':
-        return FontAwesomeIcons.bell;
+        return FontAwesomeIcons.bell.data;
       case 'bell_solid':
-        return FontAwesomeIcons.solidBell;
+        return FontAwesomeIcons.solidBell.data;
       case 'home':
-        return FontAwesomeIcons.house;
+        return FontAwesomeIcons.house.data;
       case 'chart_bar':
-        return FontAwesomeIcons.chartBar;
+        return FontAwesomeIcons.chartBar.data;
       case 'chart_line':
-        return FontAwesomeIcons.chartLine;
+        return FontAwesomeIcons.chartLine.data;
       case 'chart_pie':
-        return FontAwesomeIcons.chartPie;
+        return FontAwesomeIcons.chartPie.data;
       case 'database':
-        return FontAwesomeIcons.database;
+        return FontAwesomeIcons.database.data;
       case 'server':
-        return FontAwesomeIcons.server;
+        return FontAwesomeIcons.server.data;
       case 'wifi':
-        return FontAwesomeIcons.wifi;
+        return FontAwesomeIcons.wifi.data;
       case 'bluetooth':
-        return FontAwesomeIcons.bluetooth;
+        return FontAwesomeIcons.bluetooth.data;
       case 'usb':
-        return FontAwesomeIcons.usb;
+        return FontAwesomeIcons.usb.data;
       case 'plug':
-        return FontAwesomeIcons.plug;
+        return FontAwesomeIcons.plug.data;
       case 'battery_full':
-        return FontAwesomeIcons.batteryFull;
+        return FontAwesomeIcons.batteryFull.data;
       case 'battery_half':
-        return FontAwesomeIcons.batteryHalf;
+        return FontAwesomeIcons.batteryHalf.data;
       case 'battery_empty':
-        return FontAwesomeIcons.batteryEmpty;
+        return FontAwesomeIcons.batteryEmpty.data;
       case 'bolt':
-        return FontAwesomeIcons.bolt;
+        return FontAwesomeIcons.bolt.data;
       case 'fire':
-        return FontAwesomeIcons.fire;
+        return FontAwesomeIcons.fire.data;
       case 'snowflake':
-        return FontAwesomeIcons.snowflake;
+        return FontAwesomeIcons.snowflake.data;
       case 'sun':
-        return FontAwesomeIcons.sun;
+        return FontAwesomeIcons.sun.data;
       case 'moon':
-        return FontAwesomeIcons.moon;
+        return FontAwesomeIcons.moon.data;
       case 'cloud':
-        return FontAwesomeIcons.cloud;
+        return FontAwesomeIcons.cloud.data;
       case 'cloud_rain':
-        return FontAwesomeIcons.cloudRain;
+        return FontAwesomeIcons.cloudRain.data;
       case 'thermometer':
-        return FontAwesomeIcons.temperatureHalf;
+        return FontAwesomeIcons.temperatureHalf.data;
       case 'tachometer':
-        return FontAwesomeIcons.gaugeHigh;
+        return FontAwesomeIcons.gaugeHigh.data;
       case 'wrench':
-        return FontAwesomeIcons.wrench;
+        return FontAwesomeIcons.wrench.data;
       case 'hammer':
-        return FontAwesomeIcons.hammer;
+        return FontAwesomeIcons.hammer.data;
       case 'screwdriver':
-        return FontAwesomeIcons.screwdriver;
+        return FontAwesomeIcons.screwdriver.data;
       case 'toolbox':
-        return FontAwesomeIcons.toolbox;
+        return FontAwesomeIcons.toolbox.data;
       case 'industry':
-        return FontAwesomeIcons.industry;
+        return FontAwesomeIcons.industry.data;
       case 'warehouse_fa':
-        return FontAwesomeIcons.warehouse;
+        return FontAwesomeIcons.warehouse.data;
       case 'warehouse_open':
         return warehouse_open;
       case 'warehouse_open1':
@@ -829,41 +829,41 @@ class IconDataConverter implements JsonConverter<IconData, String> {
       case 'warehouse_closed':
         return warehouse_closed;
       case 'truck':
-        return FontAwesomeIcons.truck;
+        return FontAwesomeIcons.truck.data;
       case 'shipping_fast':
-        return FontAwesomeIcons.truckFast;
+        return FontAwesomeIcons.truckFast.data;
       case 'box':
-        return FontAwesomeIcons.box;
+        return FontAwesomeIcons.box.data;
       case 'boxes':
-        return FontAwesomeIcons.boxesStacked;
+        return FontAwesomeIcons.boxesStacked.data;
       case 'clipboard':
-        return FontAwesomeIcons.clipboard;
+        return FontAwesomeIcons.clipboard.data;
       case 'clipboard_list':
-        return FontAwesomeIcons.clipboardList;
+        return FontAwesomeIcons.clipboardList.data;
       case 'tasks':
-        return FontAwesomeIcons.listCheck;
+        return FontAwesomeIcons.listCheck.data;
       case 'project_diagram':
-        return FontAwesomeIcons.diagramProject;
+        return FontAwesomeIcons.diagramProject.data;
       case 'sitemap':
-        return FontAwesomeIcons.sitemap;
+        return FontAwesomeIcons.sitemap.data;
       case 'network_wired':
-        return FontAwesomeIcons.networkWired;
+        return FontAwesomeIcons.networkWired.data;
       case 'microchip':
-        return FontAwesomeIcons.microchip;
+        return FontAwesomeIcons.microchip.data;
       case 'memory':
-        return FontAwesomeIcons.memory;
+        return FontAwesomeIcons.memory.data;
       case 'hdd':
-        return FontAwesomeIcons.hardDrive;
+        return FontAwesomeIcons.hardDrive.data;
       case 'laptop':
-        return FontAwesomeIcons.laptop;
+        return FontAwesomeIcons.laptop.data;
       case 'mobile_alt':
-        return FontAwesomeIcons.mobileScreenButton;
+        return FontAwesomeIcons.mobileScreenButton.data;
       case 'tablet':
-        return FontAwesomeIcons.tablet;
+        return FontAwesomeIcons.tablet.data;
       case 'desktop':
-        return FontAwesomeIcons.desktop;
+        return FontAwesomeIcons.desktop.data;
       case 'tv':
-        return FontAwesomeIcons.tv;
+        return FontAwesomeIcons.tv.data;
 
       // Custom Icon
       case 'baader':
@@ -1195,112 +1195,112 @@ class IconDataConverter implements JsonConverter<IconData, String> {
     if (iconData == Icons.settings_voice) return 'settings_voice';
 
     // FontAwesome Icons
-    if (iconData == FontAwesomeIcons.weightScale) return 'weight_scale';
-    if (iconData == FontAwesomeIcons.scaleBalanced) return 'scale_balanced';
-    if (iconData == FontAwesomeIcons.weightHanging) return 'weight_hanging';
-    if (iconData == FontAwesomeIcons.bullseye) return 'bullseye';
-    if (iconData == FontAwesomeIcons.ruler) return 'ruler';
-    if (iconData == FontAwesomeIcons.anchor) return 'anchor';
-    if (iconData == FontAwesomeIcons.magnifyingGlassLocation)
+    if (iconData == FontAwesomeIcons.weightScale.data) return 'weight_scale';
+    if (iconData == FontAwesomeIcons.scaleBalanced.data) return 'scale_balanced';
+    if (iconData == FontAwesomeIcons.weightHanging.data) return 'weight_hanging';
+    if (iconData == FontAwesomeIcons.bullseye.data) return 'bullseye';
+    if (iconData == FontAwesomeIcons.ruler.data) return 'ruler';
+    if (iconData == FontAwesomeIcons.anchor.data) return 'anchor';
+    if (iconData == FontAwesomeIcons.magnifyingGlassLocation.data)
       return 'magnifying_glass_location';
-    if (iconData == FontAwesomeIcons.slash) return 'slash';
-    if (iconData == FontAwesomeIcons.dumbbell) return 'dumbbell';
-    if (iconData == FontAwesomeIcons.play) return 'play';
-    if (iconData == FontAwesomeIcons.pause) return 'pause_fa';
-    if (iconData == FontAwesomeIcons.stop) return 'stop_fa';
-    if (iconData == FontAwesomeIcons.car) return 'car';
-    if (iconData == FontAwesomeIcons.droplet) return 'droplet';
+    if (iconData == FontAwesomeIcons.slash.data) return 'slash';
+    if (iconData == FontAwesomeIcons.dumbbell.data) return 'dumbbell';
+    if (iconData == FontAwesomeIcons.play.data) return 'play';
+    if (iconData == FontAwesomeIcons.pause.data) return 'pause_fa';
+    if (iconData == FontAwesomeIcons.stop.data) return 'stop_fa';
+    if (iconData == FontAwesomeIcons.car.data) return 'car';
+    if (iconData == FontAwesomeIcons.droplet.data) return 'droplet';
 
     // Additional commonly used FontAwesome icons
-    if (iconData == FontAwesomeIcons.heart) return 'heart';
-    if (iconData == FontAwesomeIcons.solidHeart) return 'heart_solid';
-    if (iconData == FontAwesomeIcons.user) return 'user';
-    if (iconData == FontAwesomeIcons.solidUser) return 'user_solid';
-    if (iconData == FontAwesomeIcons.envelope) return 'envelope';
-    if (iconData == FontAwesomeIcons.solidEnvelope) return 'envelope_solid';
-    if (iconData == FontAwesomeIcons.phone) return 'fa_phone';
-    if (iconData == FontAwesomeIcons.calendar) return 'calendar';
-    if (iconData == FontAwesomeIcons.solidCalendar) return 'calendar_solid';
-    if (iconData == FontAwesomeIcons.clock) return 'clock';
-    if (iconData == FontAwesomeIcons.solidClock) return 'clock_solid';
-    if (iconData == FontAwesomeIcons.locationDot) return 'map_marker';
-    if (iconData == FontAwesomeIcons.globe) return 'globe';
-    if (iconData == FontAwesomeIcons.gear) return 'cog';
-    if (iconData == FontAwesomeIcons.bars) return 'bars';
-    if (iconData == FontAwesomeIcons.xmark) return 'times';
-    if (iconData == FontAwesomeIcons.check) return 'check';
-    if (iconData == FontAwesomeIcons.plus) return 'plus';
-    if (iconData == FontAwesomeIcons.minus) return 'minus';
-    if (iconData == FontAwesomeIcons.magnifyingGlass) return 'search';
-    if (iconData == FontAwesomeIcons.penToSquare) return 'edit';
-    if (iconData == FontAwesomeIcons.trash) return 'trash';
-    if (iconData == FontAwesomeIcons.download) return 'download';
-    if (iconData == FontAwesomeIcons.upload) return 'upload';
-    if (iconData == FontAwesomeIcons.share) return 'share';
-    if (iconData == FontAwesomeIcons.eye) return 'eye';
-    if (iconData == FontAwesomeIcons.eyeSlash) return 'eye_slash';
-    if (iconData == FontAwesomeIcons.lock) return 'lock';
-    if (iconData == FontAwesomeIcons.unlock) return 'unlock';
-    if (iconData == FontAwesomeIcons.key) return 'key';
-    if (iconData == FontAwesomeIcons.shieldHalved) return 'shield_alt';
-    if (iconData == FontAwesomeIcons.star) return 'star';
-    if (iconData == FontAwesomeIcons.solidStar) return 'star_solid';
-    if (iconData == FontAwesomeIcons.thumbsUp) return 'thumbs_up';
-    if (iconData == FontAwesomeIcons.thumbsDown) return 'thumbs_down';
-    if (iconData == FontAwesomeIcons.comment) return 'comment';
-    if (iconData == FontAwesomeIcons.solidComment) return 'comment_solid';
-    if (iconData == FontAwesomeIcons.bell) return 'bell';
-    if (iconData == FontAwesomeIcons.solidBell) return 'bell_solid';
-    if (iconData == FontAwesomeIcons.house) return 'home';
-    if (iconData == FontAwesomeIcons.chartBar) return 'chart_bar';
-    if (iconData == FontAwesomeIcons.chartLine) return 'chart_line';
-    if (iconData == FontAwesomeIcons.chartPie) return 'chart_pie';
-    if (iconData == FontAwesomeIcons.database) return 'database';
-    if (iconData == FontAwesomeIcons.server) return 'server';
-    if (iconData == FontAwesomeIcons.wifi) return 'wifi';
-    if (iconData == FontAwesomeIcons.bluetooth) return 'bluetooth';
-    if (iconData == FontAwesomeIcons.usb) return 'usb';
-    if (iconData == FontAwesomeIcons.plug) return 'plug';
-    if (iconData == FontAwesomeIcons.batteryFull) return 'battery_full';
-    if (iconData == FontAwesomeIcons.batteryHalf) return 'battery_half';
-    if (iconData == FontAwesomeIcons.batteryEmpty) return 'battery_empty';
-    if (iconData == FontAwesomeIcons.bolt) return 'bolt';
-    if (iconData == FontAwesomeIcons.fire) return 'fire';
-    if (iconData == FontAwesomeIcons.snowflake) return 'snowflake';
-    if (iconData == FontAwesomeIcons.sun) return 'sun';
-    if (iconData == FontAwesomeIcons.moon) return 'moon';
-    if (iconData == FontAwesomeIcons.cloud) return 'cloud';
-    if (iconData == FontAwesomeIcons.cloudRain) return 'cloud_rain';
-    if (iconData == FontAwesomeIcons.temperatureHalf) return 'thermometer';
-    if (iconData == FontAwesomeIcons.gaugeHigh) return 'tachometer';
-    if (iconData == FontAwesomeIcons.wrench) return 'wrench';
-    if (iconData == FontAwesomeIcons.hammer) return 'hammer';
-    if (iconData == FontAwesomeIcons.screwdriver) return 'screwdriver';
-    if (iconData == FontAwesomeIcons.toolbox) return 'toolbox';
-    if (iconData == FontAwesomeIcons.industry) return 'industry';
-    if (iconData == FontAwesomeIcons.warehouse) return 'warehouse_fa';
+    if (iconData == FontAwesomeIcons.heart.data) return 'heart';
+    if (iconData == FontAwesomeIcons.solidHeart.data) return 'heart_solid';
+    if (iconData == FontAwesomeIcons.user.data) return 'user';
+    if (iconData == FontAwesomeIcons.solidUser.data) return 'user_solid';
+    if (iconData == FontAwesomeIcons.envelope.data) return 'envelope';
+    if (iconData == FontAwesomeIcons.solidEnvelope.data) return 'envelope_solid';
+    if (iconData == FontAwesomeIcons.phone.data) return 'fa_phone';
+    if (iconData == FontAwesomeIcons.calendar.data) return 'calendar';
+    if (iconData == FontAwesomeIcons.solidCalendar.data) return 'calendar_solid';
+    if (iconData == FontAwesomeIcons.clock.data) return 'clock';
+    if (iconData == FontAwesomeIcons.solidClock.data) return 'clock_solid';
+    if (iconData == FontAwesomeIcons.locationDot.data) return 'map_marker';
+    if (iconData == FontAwesomeIcons.globe.data) return 'globe';
+    if (iconData == FontAwesomeIcons.gear.data) return 'cog';
+    if (iconData == FontAwesomeIcons.bars.data) return 'bars';
+    if (iconData == FontAwesomeIcons.xmark.data) return 'times';
+    if (iconData == FontAwesomeIcons.check.data) return 'check';
+    if (iconData == FontAwesomeIcons.plus.data) return 'plus';
+    if (iconData == FontAwesomeIcons.minus.data) return 'minus';
+    if (iconData == FontAwesomeIcons.magnifyingGlass.data) return 'search';
+    if (iconData == FontAwesomeIcons.penToSquare.data) return 'edit';
+    if (iconData == FontAwesomeIcons.trash.data) return 'trash';
+    if (iconData == FontAwesomeIcons.download.data) return 'download';
+    if (iconData == FontAwesomeIcons.upload.data) return 'upload';
+    if (iconData == FontAwesomeIcons.share.data) return 'share';
+    if (iconData == FontAwesomeIcons.eye.data) return 'eye';
+    if (iconData == FontAwesomeIcons.eyeSlash.data) return 'eye_slash';
+    if (iconData == FontAwesomeIcons.lock.data) return 'lock';
+    if (iconData == FontAwesomeIcons.unlock.data) return 'unlock';
+    if (iconData == FontAwesomeIcons.key.data) return 'key';
+    if (iconData == FontAwesomeIcons.shieldHalved.data) return 'shield_alt';
+    if (iconData == FontAwesomeIcons.star.data) return 'star';
+    if (iconData == FontAwesomeIcons.solidStar.data) return 'star_solid';
+    if (iconData == FontAwesomeIcons.thumbsUp.data) return 'thumbs_up';
+    if (iconData == FontAwesomeIcons.thumbsDown.data) return 'thumbs_down';
+    if (iconData == FontAwesomeIcons.comment.data) return 'comment';
+    if (iconData == FontAwesomeIcons.solidComment.data) return 'comment_solid';
+    if (iconData == FontAwesomeIcons.bell.data) return 'bell';
+    if (iconData == FontAwesomeIcons.solidBell.data) return 'bell_solid';
+    if (iconData == FontAwesomeIcons.house.data) return 'home';
+    if (iconData == FontAwesomeIcons.chartBar.data) return 'chart_bar';
+    if (iconData == FontAwesomeIcons.chartLine.data) return 'chart_line';
+    if (iconData == FontAwesomeIcons.chartPie.data) return 'chart_pie';
+    if (iconData == FontAwesomeIcons.database.data) return 'database';
+    if (iconData == FontAwesomeIcons.server.data) return 'server';
+    if (iconData == FontAwesomeIcons.wifi.data) return 'wifi';
+    if (iconData == FontAwesomeIcons.bluetooth.data) return 'bluetooth';
+    if (iconData == FontAwesomeIcons.usb.data) return 'usb';
+    if (iconData == FontAwesomeIcons.plug.data) return 'plug';
+    if (iconData == FontAwesomeIcons.batteryFull.data) return 'battery_full';
+    if (iconData == FontAwesomeIcons.batteryHalf.data) return 'battery_half';
+    if (iconData == FontAwesomeIcons.batteryEmpty.data) return 'battery_empty';
+    if (iconData == FontAwesomeIcons.bolt.data) return 'bolt';
+    if (iconData == FontAwesomeIcons.fire.data) return 'fire';
+    if (iconData == FontAwesomeIcons.snowflake.data) return 'snowflake';
+    if (iconData == FontAwesomeIcons.sun.data) return 'sun';
+    if (iconData == FontAwesomeIcons.moon.data) return 'moon';
+    if (iconData == FontAwesomeIcons.cloud.data) return 'cloud';
+    if (iconData == FontAwesomeIcons.cloudRain.data) return 'cloud_rain';
+    if (iconData == FontAwesomeIcons.temperatureHalf.data) return 'thermometer';
+    if (iconData == FontAwesomeIcons.gaugeHigh.data) return 'tachometer';
+    if (iconData == FontAwesomeIcons.wrench.data) return 'wrench';
+    if (iconData == FontAwesomeIcons.hammer.data) return 'hammer';
+    if (iconData == FontAwesomeIcons.screwdriver.data) return 'screwdriver';
+    if (iconData == FontAwesomeIcons.toolbox.data) return 'toolbox';
+    if (iconData == FontAwesomeIcons.industry.data) return 'industry';
+    if (iconData == FontAwesomeIcons.warehouse.data) return 'warehouse_fa';
     if (iconData == warehouse_open) return 'warehouse_open';
     if (iconData == warehouse_open1) return 'warehouse_open1';
     if (iconData == warehouse_open2) return 'warehouse_open2';
     if (iconData == warehouse_closed) return 'warehouse_closed';
-    if (iconData == FontAwesomeIcons.truck) return 'truck';
-    if (iconData == FontAwesomeIcons.truckFast) return 'shipping_fast';
-    if (iconData == FontAwesomeIcons.box) return 'box';
-    if (iconData == FontAwesomeIcons.boxesStacked) return 'boxes';
-    if (iconData == FontAwesomeIcons.clipboard) return 'clipboard';
-    if (iconData == FontAwesomeIcons.clipboardList) return 'clipboard_list';
-    if (iconData == FontAwesomeIcons.listCheck) return 'tasks';
-    if (iconData == FontAwesomeIcons.diagramProject) return 'project_diagram';
-    if (iconData == FontAwesomeIcons.sitemap) return 'sitemap';
-    if (iconData == FontAwesomeIcons.networkWired) return 'network_wired';
-    if (iconData == FontAwesomeIcons.microchip) return 'microchip';
-    if (iconData == FontAwesomeIcons.memory) return 'memory';
-    if (iconData == FontAwesomeIcons.hardDrive) return 'hdd';
-    if (iconData == FontAwesomeIcons.laptop) return 'laptop';
-    if (iconData == FontAwesomeIcons.mobileScreenButton) return 'mobile_alt';
-    if (iconData == FontAwesomeIcons.tablet) return 'tablet';
-    if (iconData == FontAwesomeIcons.desktop) return 'desktop';
-    if (iconData == FontAwesomeIcons.tv) return 'tv';
+    if (iconData == FontAwesomeIcons.truck.data) return 'truck';
+    if (iconData == FontAwesomeIcons.truckFast.data) return 'shipping_fast';
+    if (iconData == FontAwesomeIcons.box.data) return 'box';
+    if (iconData == FontAwesomeIcons.boxesStacked.data) return 'boxes';
+    if (iconData == FontAwesomeIcons.clipboard.data) return 'clipboard';
+    if (iconData == FontAwesomeIcons.clipboardList.data) return 'clipboard_list';
+    if (iconData == FontAwesomeIcons.listCheck.data) return 'tasks';
+    if (iconData == FontAwesomeIcons.diagramProject.data) return 'project_diagram';
+    if (iconData == FontAwesomeIcons.sitemap.data) return 'sitemap';
+    if (iconData == FontAwesomeIcons.networkWired.data) return 'network_wired';
+    if (iconData == FontAwesomeIcons.microchip.data) return 'microchip';
+    if (iconData == FontAwesomeIcons.memory.data) return 'memory';
+    if (iconData == FontAwesomeIcons.hardDrive.data) return 'hdd';
+    if (iconData == FontAwesomeIcons.laptop.data) return 'laptop';
+    if (iconData == FontAwesomeIcons.mobileScreenButton.data) return 'mobile_alt';
+    if (iconData == FontAwesomeIcons.tablet.data) return 'tablet';
+    if (iconData == FontAwesomeIcons.desktop.data) return 'desktop';
+    if (iconData == FontAwesomeIcons.tv.data) return 'tv';
 
     // Custom Icon
     if (iconData == baadericon) return 'baader';
@@ -1308,7 +1308,7 @@ class IconDataConverter implements JsonConverter<IconData, String> {
   }
 }
 
-const List<IconData> iconList = [
+final List<IconData> iconList = <IconData>[
   // Navigation & Basic UI
   Icons.home,
   Icons.settings,
@@ -1650,107 +1650,107 @@ const List<IconData> iconList = [
   Icons.settings_voice,
 
   // FontAwesome Icons
-  FontAwesomeIcons.weightScale,
-  FontAwesomeIcons.scaleBalanced,
-  FontAwesomeIcons.weightHanging,
-  FontAwesomeIcons.bullseye,
-  FontAwesomeIcons.ruler,
-  FontAwesomeIcons.anchor,
-  FontAwesomeIcons.magnifyingGlassLocation,
-  FontAwesomeIcons.slash,
-  FontAwesomeIcons.dumbbell,
-  FontAwesomeIcons.play,
-  FontAwesomeIcons.pause,
-  FontAwesomeIcons.stop,
-  FontAwesomeIcons.car,
-  FontAwesomeIcons.droplet,
+  FontAwesomeIcons.weightScale.data,
+  FontAwesomeIcons.scaleBalanced.data,
+  FontAwesomeIcons.weightHanging.data,
+  FontAwesomeIcons.bullseye.data,
+  FontAwesomeIcons.ruler.data,
+  FontAwesomeIcons.anchor.data,
+  FontAwesomeIcons.magnifyingGlassLocation.data,
+  FontAwesomeIcons.slash.data,
+  FontAwesomeIcons.dumbbell.data,
+  FontAwesomeIcons.play.data,
+  FontAwesomeIcons.pause.data,
+  FontAwesomeIcons.stop.data,
+  FontAwesomeIcons.car.data,
+  FontAwesomeIcons.droplet.data,
 
   // Additional commonly used FontAwesome icons
-  FontAwesomeIcons.heart,
-  FontAwesomeIcons.solidHeart,
-  FontAwesomeIcons.user,
-  FontAwesomeIcons.solidUser,
-  FontAwesomeIcons.envelope,
-  FontAwesomeIcons.solidEnvelope,
-  FontAwesomeIcons.phone,
-  FontAwesomeIcons.calendar,
-  FontAwesomeIcons.solidCalendar,
-  FontAwesomeIcons.clock,
-  FontAwesomeIcons.solidClock,
-  FontAwesomeIcons.locationDot,
-  FontAwesomeIcons.globe,
-  FontAwesomeIcons.gear,
-  FontAwesomeIcons.bars,
-  FontAwesomeIcons.xmark,
-  FontAwesomeIcons.check,
-  FontAwesomeIcons.plus,
-  FontAwesomeIcons.minus,
-  FontAwesomeIcons.magnifyingGlass,
-  FontAwesomeIcons.penToSquare,
-  FontAwesomeIcons.trash,
-  FontAwesomeIcons.download,
-  FontAwesomeIcons.upload,
-  FontAwesomeIcons.share,
-  FontAwesomeIcons.eye,
-  FontAwesomeIcons.eyeSlash,
-  FontAwesomeIcons.lock,
-  FontAwesomeIcons.unlock,
-  FontAwesomeIcons.key,
-  FontAwesomeIcons.shieldHalved,
-  FontAwesomeIcons.star,
-  FontAwesomeIcons.solidStar,
-  FontAwesomeIcons.thumbsUp,
-  FontAwesomeIcons.thumbsDown,
-  FontAwesomeIcons.comment,
-  FontAwesomeIcons.solidComment,
-  FontAwesomeIcons.bell,
-  FontAwesomeIcons.solidBell,
-  FontAwesomeIcons.house,
-  FontAwesomeIcons.chartBar,
-  FontAwesomeIcons.chartLine,
-  FontAwesomeIcons.chartPie,
-  FontAwesomeIcons.database,
-  FontAwesomeIcons.server,
-  FontAwesomeIcons.wifi,
-  FontAwesomeIcons.bluetooth,
-  FontAwesomeIcons.usb,
-  FontAwesomeIcons.plug,
-  FontAwesomeIcons.batteryFull,
-  FontAwesomeIcons.batteryHalf,
-  FontAwesomeIcons.batteryEmpty,
-  FontAwesomeIcons.bolt,
-  FontAwesomeIcons.fire,
-  FontAwesomeIcons.snowflake,
-  FontAwesomeIcons.sun,
-  FontAwesomeIcons.moon,
-  FontAwesomeIcons.cloud,
-  FontAwesomeIcons.cloudRain,
-  FontAwesomeIcons.temperatureHalf,
-  FontAwesomeIcons.gaugeHigh,
-  FontAwesomeIcons.wrench,
-  FontAwesomeIcons.hammer,
-  FontAwesomeIcons.screwdriver,
-  FontAwesomeIcons.toolbox,
-  FontAwesomeIcons.industry,
-  FontAwesomeIcons.warehouse,
-  FontAwesomeIcons.truck,
-  FontAwesomeIcons.truckFast,
-  FontAwesomeIcons.box,
-  FontAwesomeIcons.boxesStacked,
-  FontAwesomeIcons.clipboard,
-  FontAwesomeIcons.clipboardList,
-  FontAwesomeIcons.listCheck,
-  FontAwesomeIcons.diagramProject,
-  FontAwesomeIcons.sitemap,
-  FontAwesomeIcons.networkWired,
-  FontAwesomeIcons.microchip,
-  FontAwesomeIcons.memory,
-  FontAwesomeIcons.hardDrive,
-  FontAwesomeIcons.laptop,
-  FontAwesomeIcons.mobileScreenButton,
-  FontAwesomeIcons.tablet,
-  FontAwesomeIcons.desktop,
-  FontAwesomeIcons.tv,
+  FontAwesomeIcons.heart.data,
+  FontAwesomeIcons.solidHeart.data,
+  FontAwesomeIcons.user.data,
+  FontAwesomeIcons.solidUser.data,
+  FontAwesomeIcons.envelope.data,
+  FontAwesomeIcons.solidEnvelope.data,
+  FontAwesomeIcons.phone.data,
+  FontAwesomeIcons.calendar.data,
+  FontAwesomeIcons.solidCalendar.data,
+  FontAwesomeIcons.clock.data,
+  FontAwesomeIcons.solidClock.data,
+  FontAwesomeIcons.locationDot.data,
+  FontAwesomeIcons.globe.data,
+  FontAwesomeIcons.gear.data,
+  FontAwesomeIcons.bars.data,
+  FontAwesomeIcons.xmark.data,
+  FontAwesomeIcons.check.data,
+  FontAwesomeIcons.plus.data,
+  FontAwesomeIcons.minus.data,
+  FontAwesomeIcons.magnifyingGlass.data,
+  FontAwesomeIcons.penToSquare.data,
+  FontAwesomeIcons.trash.data,
+  FontAwesomeIcons.download.data,
+  FontAwesomeIcons.upload.data,
+  FontAwesomeIcons.share.data,
+  FontAwesomeIcons.eye.data,
+  FontAwesomeIcons.eyeSlash.data,
+  FontAwesomeIcons.lock.data,
+  FontAwesomeIcons.unlock.data,
+  FontAwesomeIcons.key.data,
+  FontAwesomeIcons.shieldHalved.data,
+  FontAwesomeIcons.star.data,
+  FontAwesomeIcons.solidStar.data,
+  FontAwesomeIcons.thumbsUp.data,
+  FontAwesomeIcons.thumbsDown.data,
+  FontAwesomeIcons.comment.data,
+  FontAwesomeIcons.solidComment.data,
+  FontAwesomeIcons.bell.data,
+  FontAwesomeIcons.solidBell.data,
+  FontAwesomeIcons.house.data,
+  FontAwesomeIcons.chartBar.data,
+  FontAwesomeIcons.chartLine.data,
+  FontAwesomeIcons.chartPie.data,
+  FontAwesomeIcons.database.data,
+  FontAwesomeIcons.server.data,
+  FontAwesomeIcons.wifi.data,
+  FontAwesomeIcons.bluetooth.data,
+  FontAwesomeIcons.usb.data,
+  FontAwesomeIcons.plug.data,
+  FontAwesomeIcons.batteryFull.data,
+  FontAwesomeIcons.batteryHalf.data,
+  FontAwesomeIcons.batteryEmpty.data,
+  FontAwesomeIcons.bolt.data,
+  FontAwesomeIcons.fire.data,
+  FontAwesomeIcons.snowflake.data,
+  FontAwesomeIcons.sun.data,
+  FontAwesomeIcons.moon.data,
+  FontAwesomeIcons.cloud.data,
+  FontAwesomeIcons.cloudRain.data,
+  FontAwesomeIcons.temperatureHalf.data,
+  FontAwesomeIcons.gaugeHigh.data,
+  FontAwesomeIcons.wrench.data,
+  FontAwesomeIcons.hammer.data,
+  FontAwesomeIcons.screwdriver.data,
+  FontAwesomeIcons.toolbox.data,
+  FontAwesomeIcons.industry.data,
+  FontAwesomeIcons.warehouse.data,
+  FontAwesomeIcons.truck.data,
+  FontAwesomeIcons.truckFast.data,
+  FontAwesomeIcons.box.data,
+  FontAwesomeIcons.boxesStacked.data,
+  FontAwesomeIcons.clipboard.data,
+  FontAwesomeIcons.clipboardList.data,
+  FontAwesomeIcons.listCheck.data,
+  FontAwesomeIcons.diagramProject.data,
+  FontAwesomeIcons.sitemap.data,
+  FontAwesomeIcons.networkWired.data,
+  FontAwesomeIcons.microchip.data,
+  FontAwesomeIcons.memory.data,
+  FontAwesomeIcons.hardDrive.data,
+  FontAwesomeIcons.laptop.data,
+  FontAwesomeIcons.mobileScreenButton.data,
+  FontAwesomeIcons.tablet.data,
+  FontAwesomeIcons.desktop.data,
+  FontAwesomeIcons.tv.data,
 
   // Custom Icon
   baadericon,

--- a/lib/page_creator/assets/start_stop_button.dart
+++ b/lib/page_creator/assets/start_stop_button.dart
@@ -320,10 +320,10 @@ class _PrettyPill extends StatelessWidget {
   }
 
   IconData _icon(_Segment s) => switch (s) {
-        _Segment.run => FontAwesomeIcons.play,
-        _Segment.clean => FontAwesomeIcons.droplet,
-        _Segment.stop => FontAwesomeIcons.stop,
-        _Segment.manual => FontAwesomeIcons.screwdriverWrench,
+        _Segment.run => FontAwesomeIcons.play.data,
+        _Segment.clean => FontAwesomeIcons.droplet.data,
+        _Segment.stop => FontAwesomeIcons.stop.data,
+        _Segment.manual => FontAwesomeIcons.screwdriverWrench.data,
       };
 
   @override

--- a/lib/pages/about_linux.dart
+++ b/lib/pages/about_linux.dart
@@ -248,7 +248,7 @@ class _AboutLinuxPageState extends State<AboutLinuxPage> {
     final confirmed = await _showConfirmDialog(
       title: 'Power Off',
       message: 'Are you sure you want to power off the system?',
-      icon: FontAwesomeIcons.powerOff,
+      icon: FontAwesomeIcons.powerOff.data,
       iconColor: Colors.red,
     );
 
@@ -270,7 +270,7 @@ class _AboutLinuxPageState extends State<AboutLinuxPage> {
     final confirmed = await _showConfirmDialog(
       title: 'Reboot',
       message: 'Are you sure you want to reboot the system?',
-      icon: FontAwesomeIcons.arrowsRotate,
+      icon: FontAwesomeIcons.arrowsRotate.data,
       iconColor: Colors.orange,
     );
 
@@ -432,7 +432,7 @@ class _AboutLinuxPageState extends State<AboutLinuxPage> {
 
                 // Facts
                 fact(
-                  icon: FontAwesomeIcons.microchip,
+                  icon: FontAwesomeIcons.microchip.data,
                   label: 'Kernel',
                   value: [
                     if (info.kernelName.isNotEmpty) info.kernelName,
@@ -442,13 +442,13 @@ class _AboutLinuxPageState extends State<AboutLinuxPage> {
                 ),
                 if (info.osPretty.isNotEmpty)
                   fact(
-                    icon: FontAwesomeIcons.boxArchive,
+                    icon: FontAwesomeIcons.boxArchive.data,
                     label: 'Operating System',
                     value: info.osPretty,
                   ),
                 if (info.osSupportEnd != null)
                   fact(
-                    icon: FontAwesomeIcons.calendarDay,
+                    icon: FontAwesomeIcons.calendarDay.data,
                     label: 'Support End',
                     value: _fmtDate(info.osSupportEnd!),
                     caption: 'From org.freedesktop.hostname1 (local time).',

--- a/lib/pages/server_config.dart
+++ b/lib/pages/server_config.dart
@@ -747,7 +747,7 @@ class _OpcUAServersSectionState extends ConsumerState<_OpcUAServersSection> {
 }
 
 class _EmptyServersPlaceholder extends StatelessWidget {
-  final IconData icon;
+  final FaIconData icon;
   final String title;
   final String subtitle;
 
@@ -784,7 +784,7 @@ class _EmptyServersPlaceholder extends StatelessWidget {
 /// a responsive header row that collapses on narrow screens.
 class _ServerSectionHeader extends StatelessWidget {
   final String title;
-  final IconData icon;
+  final FaIconData icon;
   final bool hasUnsavedChanges;
   final VoidCallback onAdd;
 

--- a/lib/tech_docs/tech_doc_picker.dart
+++ b/lib/tech_docs/tech_doc_picker.dart
@@ -200,9 +200,13 @@ class _TechDocDropdownOverlay extends StatelessWidget {
             child: Material(
               elevation: 8,
               borderRadius: BorderRadius.circular(8),
+              // The surface colour lives on the Material rather than the
+              // Container below: ListTile paints its ink splashes on the
+              // nearest Material ancestor, so a coloured DecoratedBox in
+              // between would hide them (asserted by Flutter >= 3.44).
+              color: Theme.of(context).colorScheme.surface,
               child: Container(
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface,
                   borderRadius: BorderRadius.circular(8),
                   border: Border.all(color: Theme.of(context).dividerColor),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shared_preferences: ^2.3.5
   file_picker: ^10.3.3
   rxdart: ^0.28.0
-  font_awesome_flutter: ^10.9.1
+  font_awesome_flutter: ^11.0.0
   riverpod: ^2.6.1
   json_annotation: ^4.9.0
   riverpod_annotation: ^2.6.1

--- a/test/page_creator/assets/advantys_stb_test.dart
+++ b/test/page_creator/assets/advantys_stb_test.dart
@@ -2999,7 +2999,7 @@ void main() {
 
         final reorderable = tester
             .widget<ReorderableListView>(find.byType(ReorderableListView));
-        reorderable.onReorder(0, 2);
+        reorderable.onReorder!(0, 2);
         await tester.pumpAndSettle();
 
         expect(cfg.subdevices.length, 3);

--- a/test/page_creator/assets/start_stop_button_widget_test.dart
+++ b/test/page_creator/assets/start_stop_button_widget_test.dart
@@ -81,7 +81,7 @@ void main() {
         ),
       ));
       await tester.pump();
-      expect(iconByData(FontAwesomeIcons.screwdriverWrench), findsNothing,
+      expect(iconByData(FontAwesomeIcons.screwdriverWrench.data), findsNothing,
           reason: 'no manual_* keys → manual segment must not render');
       // Preview has no cleanKey either → 2 segments (run + stop).
       expect(segmentGestureDetectors(), findsNWidgets(2));
@@ -109,7 +109,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(iconByData(FontAwesomeIcons.screwdriverWrench), findsOneWidget,
+      expect(iconByData(FontAwesomeIcons.screwdriverWrench.data), findsOneWidget,
           reason: 'manualStateKey present → manual icon visible');
       // 3 segments: run + stop + manual.
       expect(segmentGestureDetectors(), findsNWidgets(3));
@@ -136,7 +136,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(iconByData(FontAwesomeIcons.screwdriverWrench), findsOneWidget,
+      expect(iconByData(FontAwesomeIcons.screwdriverWrench.data), findsOneWidget,
           reason: 'manualCommandKey present → manual icon visible');
     });
   });
@@ -167,7 +167,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       final manualIcon =
-          tester.widget<Icon>(iconByData(FontAwesomeIcons.screwdriverWrench));
+          tester.widget<Icon>(iconByData(FontAwesomeIcons.screwdriverWrench.data));
       // Manual's accent color is orange (industrial convention for
       // operator override).
       expect(manualIcon.color, Colors.orange,
@@ -202,7 +202,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       final manualIcon =
-          tester.widget<Icon>(iconByData(FontAwesomeIcons.screwdriverWrench));
+          tester.widget<Icon>(iconByData(FontAwesomeIcons.screwdriverWrench.data));
       expect(manualIcon.color, isNot(Colors.orange),
           reason: 'stream=false → manual icon does NOT paint in accent');
     });
@@ -236,7 +236,7 @@ void main() {
       // Tap the manual icon. Use tap-down to mirror how the other modes
       // pulse on press.
       final gesture =
-          await tester.startGesture(tester.getCenter(iconByData(FontAwesomeIcons.screwdriverWrench)));
+          await tester.startGesture(tester.getCenter(iconByData(FontAwesomeIcons.screwdriverWrench.data)));
       await tester.pump(const Duration(milliseconds: 20));
       await gesture.up();
       await tester.pump(const Duration(milliseconds: 20));

--- a/test/pages/key_repository_test.dart
+++ b/test/pages/key_repository_test.dart
@@ -114,7 +114,7 @@ void main() {
 
       // Tap the copy button
       final copyButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy.data);
       expect(copyButtons, findsOneWidget);
       await tester.tap(copyButtons.first);
       await tester.pumpAndSettle();
@@ -160,7 +160,7 @@ void main() {
 
       // Copy the second key
       final copyButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy.data);
       // second_key is the 2nd card, so its copy button is at index 1
       await tester.tap(copyButtons.at(1));
       await tester.pumpAndSettle();
@@ -212,7 +212,7 @@ void main() {
 
       // Copy the key
       final copyButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy.data);
       await tester.tap(copyButtons.first);
       await tester.pumpAndSettle();
 
@@ -261,7 +261,7 @@ void main() {
 
       // Copy the key (creates 'original_copy', auto-expanded)
       final copyButton = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy.data);
       await tester.tap(copyButton.first);
       await tester.pumpAndSettle();
 
@@ -302,7 +302,7 @@ void main() {
       // Copy twice — scroll back to the original's copy button each time
       for (var i = 0; i < 2; i++) {
         final copyButtons = find.byWidgetPredicate(
-            (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy);
+            (w) => w is FaIcon && w.icon == FontAwesomeIcons.copy.data);
         await tester.ensureVisible(copyButtons.first);
         await tester.pumpAndSettle();
         await tester.tap(copyButtons.first);
@@ -327,7 +327,7 @@ void main() {
 
       // Tap the first delete button (trash icon)
       final trashButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data);
       await tester.tap(trashButtons.first);
       await tester.pumpAndSettle();
 
@@ -350,7 +350,7 @@ void main() {
 
       // Tap delete
       final trashButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data);
       await tester.tap(trashButtons.first);
       await tester.pumpAndSettle();
 
@@ -373,7 +373,7 @@ void main() {
 
       // Tap delete
       final trashButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data);
       await tester.tap(trashButtons.first);
       await tester.pumpAndSettle();
 
@@ -1499,7 +1499,7 @@ void main() {
       // both subtract 1 in that case.
       final reorderable =
           tester.widget<ReorderableListView>(find.byType(ReorderableListView));
-      reorderable.onReorder(0, 3);
+      reorderable.onReorder!(0, 3);
       await tester.pumpAndSettle();
 
       // Visual order updated: alpha is now last.
@@ -1530,7 +1530,7 @@ void main() {
       final reorderable =
           tester.widget<ReorderableListView>(find.byType(ReorderableListView));
       // Drag last (index 2) to before-first (index 0).
-      reorderable.onReorder(2, 0);
+      reorderable.onReorder!(2, 0);
       await tester.pumpAndSettle();
 
       expect(titleOrder(tester), ['charlie', 'alpha', 'bravo']);

--- a/test/pages/server_config_test.dart
+++ b/test/pages/server_config_test.dart
@@ -44,7 +44,7 @@ void main() {
 
       // Find the networkWired icon within the Modbus section
       final networkWiredIcons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.networkWired);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.networkWired.data);
       expect(networkWiredIcons, findsAtLeastNWidgets(1));
     });
 
@@ -158,7 +158,7 @@ void main() {
       // Find trash icon buttons in the Modbus section area.
       // Tap the last trash button (belongs to Modbus card).
       final trashButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data);
       await tester.tap(trashButtons.last);
       await settle(tester);
 
@@ -186,7 +186,7 @@ void main() {
 
       // Tap delete (last trash button)
       final trashButtons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data);
       await tester.tap(trashButtons.last);
       await settle(tester);
 
@@ -352,7 +352,7 @@ void main() {
       // Find trash icons within poll group rows -- the small ones (size 14)
       // The server card trash is size 16, poll group trash is size 14
       final pollGroupTrashIcons = find.byWidgetPredicate(
-          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash && w.size == 14);
+          (w) => w is FaIcon && w.icon == FontAwesomeIcons.trash.data && w.size == 14);
       expect(pollGroupTrashIcons, findsAtLeastNWidgets(1));
 
       // Tap first poll group trash icon

--- a/test/widgets/browse_panel_test.dart
+++ b/test/widgets/browse_panel_test.dart
@@ -418,7 +418,7 @@ void main() {
       expect(find.byIcon(Icons.play_arrow), findsOneWidget);
       expect(
         find.byWidgetPredicate(
-            (w) => w is FaIcon && w.icon == FontAwesomeIcons.tag),
+            (w) => w is FaIcon && w.icon == FontAwesomeIcons.tag.data),
         findsOneWidget,
       );
     });

--- a/test/widgets/opcua_browse_test.dart
+++ b/test/widgets/opcua_browse_test.dart
@@ -446,7 +446,7 @@ void main() {
       // FaIcon uses RichText, not Icon, so find.byIcon won't work
       expect(
         find.byWidgetPredicate(
-            (w) => w is FaIcon && w.icon == FontAwesomeIcons.tag),
+            (w) => w is FaIcon && w.icon == FontAwesomeIcons.tag.data),
         findsOneWidget,
       );
     });


### PR DESCRIPTION
Lifts the CI Flutter pin added in #123. That pin existed because every published `font_awesome_flutter` 10.x subclasses `IconData`, which stopped compiling once Flutter made `IconData` a `final class`:

```
font_awesome_flutter-10.12.0/lib/src/icon_data.dart:6:30:
Error: The class 'IconData' can't be extended outside of its
library because it's a final class.
```

`font_awesome_flutter` **11.0.0** fixes this upstream exactly as #123 anticipated — subclassing was replaced with composition (`final class FaIconData { final IconData data; ... }`). That is a breaking API change, so this PR migrates the callers.

## font_awesome 10 → 11

`FaIcon` now takes `FaIconData`, so the ~440 `FaIcon(FontAwesomeIcons.x)` call sites are **unchanged**. Only places using a Font Awesome icon *as* an `IconData` needed work:

| File | Change |
|---|---|
| `lib/converter/icon.dart` | `.data` on all 297 `FontAwesomeIcons` refs; `const iconList` → `final` |
| `lib/pages/server_config.dart` | Two widget `icon` fields retyped `IconData` → `FaIconData` (they render via `FaIcon`) |
| `about_linux.dart`, `start_stop_button.dart`, `centroid-hmi/lib/main.dart` | `.data` (these render via plain `Icon`) |
| 6 test files | `.data` on `w.icon == FontAwesomeIcons.x` comparisons |

### One subtle bug worth flagging

99 of the converter changes were `iconData == FontAwesomeIcons.x` comparisons in `_getIconName()`. Under v11 these compare `IconData` to `FaIconData` — **always false** — and the analyzer reports this only as `unrelated_type_equality_checks` (info, *not* an error). Left alone, `_getIconName` would have silently returned the fallback name for every Font Awesome icon, breaking icon round-tripping in saved pages. Same class of issue in the widget-test finders.

`iconList` had to drop `const` because `FaIconData.data` is not a constant expression; it is only ever used at runtime (`.length`, `[index]`, `.map`).

`about_linux.dart`'s 3 genuine `FaIcon` uses are deliberately left alone rather than blanket-patched.

## Flutter 3.41.9 → 3.44.9 fallout

- `ReorderableListView.onReorder` is now nullable (and gained `onReorderItem`) → 3 test call sites need `!`.
- Flutter 3.44 added an assertion that a `ListTile` under a colour-bearing `DecoratedBox` hides its own ink splashes. `TechDocPicker`'s dropdown hit this (`Material` > coloured `Container` > `ListTile`), failing 9 tests. Moving the surface colour onto the `Material` fixes the splashes and keeps the visual identical.

## macOS Xcode files

`Podfile.lock` / `project.pbxproj` / `Runner.xcscheme` / `Package.resolved` are Flutter 3.44's **automatic** project migration, which moves most plugins from CocoaPods to Swift Package Manager — hence the shrunken `Podfile.lock` and the new SPM pins.

> [!NOTE]
> Anyone building macOS while still on 3.41.9 will regenerate these back. Worth coordinating the local SDK bump.

## Verification

Run against a side-by-side 3.44.9 SDK (Homebrew Flutter left at 3.41.9):

| Check | 3.41.9 | 3.44.9 |
|---|---|---|
| `flutter test test/` | ✅ 2146/2146 | ✅ 2146/2146 |
| `flutter build macos --release` | ✅ | ✅ |
| `flutter analyze` error count | 9149 (baseline) | 9149 — identical set |

The 9149 analyzer errors are **pre-existing** root-analysis noise (`packages/*/test` are unresolved when analyzing from the monorepo root); CI does not run `flutter analyze`. Confirmed byte-identical to the pre-change baseline, so this PR adds none.

Still green on 3.41.9, so local environments are not forced to upgrade immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)