### PR TITLE
fix(preferences): keep unsaved edits when scrolling; Enter confirms delete

### DIFF
--- a/lib/widgets/preferences.dart
+++ b/lib/widgets/preferences.dart
@@ -9,7 +9,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tfc/providers/database.dart';
 import 'package:tfc_mcp_server/tfc_mcp_server.dart'
-    show McpConfig, McpToolToggles, readMcpConfigFromPreferences, writeMcpConfigToPreferences;
+    show
+        McpConfig,
+        McpToolToggles,
+        readMcpConfigFromPreferences,
+        writeMcpConfigToPreferences;
 
 import '../providers/mcp_bridge.dart';
 import '../providers/preferences.dart';
@@ -600,12 +604,28 @@ class PreferencesKeysWidget extends ConsumerStatefulWidget {
       _PreferencesKeysWidgetState();
 }
 
-class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget> {
+class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget>
+    with AutomaticKeepAliveClientMixin {
   Map<String, Object?>? _allPrefs;
   Map<String, bool>? _dbKeyFlags;
   Preferences? _preferences;
   SharedPreferencesWrapper? _localPrefs;
   bool _loading = true;
+
+  // Unsaved editor contents and which row is open, held here rather than in
+  // the row itself. Both lists below are lazy — the page-level ListView and
+  // the key list — so a row is unmounted (and its State disposed) as soon as
+  // it scrolls past the cache extent, and re-attaching the section rebuilds
+  // every row from scratch. Anything the user has typed must therefore live
+  // above both lists to survive.
+  final Map<String, String> _drafts = {};
+  String? _expandedKey;
+
+  // Keeps this section itself mounted when the page scrolls past it, which is
+  // what makes _drafts a safe place to keep that state (and avoids reloading
+  // every preference value on the way back).
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
@@ -650,6 +670,7 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context); // AutomaticKeepAliveClientMixin
     final prefsAsync = ref.watch(preferencesProvider);
 
     return prefsAsync.when(
@@ -695,68 +716,99 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget> {
                 ),
                 const SizedBox(height: 16),
                 Expanded(
-                  child: ListView(
-                    children: sortedEntries
-                        .map(
-                          (e) => _PreferenceKeyTile(
-                            keyName: e.key,
-                            value: e.value,
-                            isInDatabase: dbFlags[e.key] ?? false,
-                            onChanged: (newValue) async {
-                              final isInDb = dbFlags[e.key] ?? false;
-                              final target = isInDb ? prefs : localPrefs;
+                  // .builder, not ListView(children:): the latter constructs
+                  // every row up front, so a row re-mounted after scrolling
+                  // would reuse a widget still holding the draft/expansion
+                  // captured at the parent's last build — i.e. before the user
+                  // typed anything. Building per row reads current state.
+                  child: ListView.builder(
+                    itemCount: sortedEntries.length,
+                    itemBuilder: (context, index) {
+                      final e = sortedEntries[index];
+                      return _PreferenceKeyTile(
+                        // Identity must follow the preference key, not the
+                        // list position: adding or deleting a key reorders
+                        // the list, and without this a kept-alive tile
+                        // would rebind to a different preference.
+                        key: ValueKey(e.key),
+                        keyName: e.key,
+                        value: e.value,
+                        isInDatabase: dbFlags[e.key] ?? false,
+                        initiallyExpanded: _expandedKey == e.key,
+                        draft: _drafts[e.key],
+                        // No setState: the row already holds this text in
+                        // its own controller, and rebuilding the list on
+                        // every keystroke would fight the editor.
+                        onDraftChanged: (text) {
+                          if (text == null) {
+                            _drafts.remove(e.key);
+                          } else {
+                            _drafts[e.key] = text;
+                          }
+                        },
+                        onExpansionChanged: (expanded) {
+                          _expandedKey = expanded ? e.key : null;
+                        },
+                        onChanged: (newValue) async {
+                          final isInDb = dbFlags[e.key] ?? false;
+                          final target = isInDb ? prefs : localPrefs;
 
-                              if (newValue is bool) {
-                                await target.setBool(e.key, newValue);
-                              } else if (newValue is int) {
-                                await target.setInt(e.key, newValue);
-                              } else if (newValue is double) {
-                                await target.setDouble(e.key, newValue);
-                              } else if (newValue is List<String>) {
-                                await target.setStringList(e.key, newValue);
-                              } else if (newValue is String) {
-                                await target.setString(e.key, newValue);
-                              }
-                              // Reload data to reflect changes
-                              _loading = true;
-                              _loadData(prefs);
-                            },
-                            onDelete: () async {
-                              final confirmed = await showDialog<bool>(
-                                context: context,
-                                builder: (context) => AlertDialog(
-                                  title: const Text('Delete Preference'),
-                                  content: Text('Delete "${e.key}"?'),
-                                  actions: [
-                                    TextButton(
-                                      onPressed: () =>
-                                          Navigator.pop(context, false),
-                                      child: const Text('Cancel'),
-                                    ),
-                                    TextButton(
-                                      onPressed: () =>
-                                          Navigator.pop(context, true),
-                                      child: const Text('Delete'),
-                                    ),
-                                  ],
+                          if (newValue is bool) {
+                            await target.setBool(e.key, newValue);
+                          } else if (newValue is int) {
+                            await target.setInt(e.key, newValue);
+                          } else if (newValue is double) {
+                            await target.setDouble(e.key, newValue);
+                          } else if (newValue is List<String>) {
+                            await target.setStringList(e.key, newValue);
+                          } else if (newValue is String) {
+                            await target.setString(e.key, newValue);
+                          }
+                          // Reload data to reflect changes
+                          _loading = true;
+                          _loadData(prefs);
+                        },
+                        onDelete: () async {
+                          final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text('Delete Preference'),
+                              content: Text('Delete "${e.key}"?'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () =>
+                                      Navigator.pop(context, false),
+                                  child: const Text('Cancel'),
                                 ),
-                              );
-                              if (confirmed == true) {
-                                final isInDb = dbFlags[e.key] ?? false;
-                                if (isInDb) {
-                                  await prefs.remove(e.key);
-                                } else {
-                                  await localPrefs.remove(e.key);
-                                }
-                                // Reload data and invalidate provider
-                                _loading = true;
-                                _loadData(prefs);
-                                ref.invalidate(preferencesProvider);
-                              }
-                            },
-                          ),
-                        )
-                        .toList(),
+                                TextButton(
+                                  // Focused on open so Enter confirms straight
+                                  // away when clearing out several keys in a
+                                  // row. Escape still dismisses without
+                                  // deleting.
+                                  autofocus: true,
+                                  onPressed: () => Navigator.pop(context, true),
+                                  child: const Text('Delete'),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirmed == true) {
+                            final isInDb = dbFlags[e.key] ?? false;
+                            if (isInDb) {
+                              await prefs.remove(e.key);
+                            } else {
+                              await localPrefs.remove(e.key);
+                            }
+                            _drafts.remove(e.key);
+                            if (_expandedKey == e.key) _expandedKey = null;
+                            // Reload data and invalidate provider
+                            _loading = true;
+                            _loadData(prefs);
+                            ref.invalidate(preferencesProvider);
+                          }
+                        },
+                      );
+                    },
                   ),
                 ),
               ],
@@ -775,12 +827,24 @@ class _PreferenceKeyTile extends StatefulWidget {
   final ValueChanged<Object?> onChanged;
   final VoidCallback onDelete;
 
+  /// Expansion and in-progress edits are owned by the parent so they outlive
+  /// this tile being unmounted by the surrounding lazy lists.
+  final bool initiallyExpanded;
+  final String? draft;
+  final ValueChanged<String?> onDraftChanged;
+  final ValueChanged<bool> onExpansionChanged;
+
   const _PreferenceKeyTile({
+    super.key,
     required this.keyName,
     required this.value,
     required this.isInDatabase,
     required this.onChanged,
     required this.onDelete,
+    required this.initiallyExpanded,
+    required this.draft,
+    required this.onDraftChanged,
+    required this.onExpansionChanged,
   });
 
   @override
@@ -791,25 +855,45 @@ class _PreferenceKeyTileState extends State<_PreferenceKeyTile> {
   late TextEditingController _controller;
   final _expansionController =
       ExpansionTileController(); // todo deprecated since 3.31
-  bool _isExpanded = false;
+  late bool _isExpanded;
+
+  String get _valueAsText => widget.value is String
+      ? widget.value as String
+      : widget.value?.toString() ?? '';
 
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController(
-      text: widget.value is String
-          ? widget.value as String
-          : widget.value?.toString() ?? '',
+    _isExpanded = widget.initiallyExpanded;
+    // Seed from the parent-held draft so an edit that outlived this State
+    // (see PreferencesKeysWidget) is restored rather than reverted.
+    _controller = TextEditingController(text: widget.draft ?? _valueAsText);
+    _controller.addListener(_reportDraft);
+  }
+
+  void _reportDraft() {
+    widget.onDraftChanged(
+      _controller.text == _valueAsText ? null : _controller.text,
     );
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_reportDraft);
+    _controller.dispose();
+    super.dispose();
   }
 
   @override
   void didUpdateWidget(covariant _PreferenceKeyTile oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.value != oldWidget.value) {
-      _controller.text = widget.value is String
-          ? widget.value as String
-          : widget.value?.toString() ?? '';
+      // A new persisted value supersedes any draft, so adopt it without
+      // reporting the change back up as an unsaved edit.
+      _controller.removeListener(_reportDraft);
+      _controller.text = _valueAsText;
+      _controller.addListener(_reportDraft);
+      widget.onDraftChanged(null);
     }
   }
 
@@ -818,6 +902,7 @@ class _PreferenceKeyTileState extends State<_PreferenceKeyTile> {
     final value = widget.value;
     return ExpansionTile(
       controller: _expansionController,
+      initiallyExpanded: widget.initiallyExpanded,
       leading: FaIcon(
         widget.isInDatabase
             ? FontAwesomeIcons.database
@@ -857,6 +942,7 @@ class _PreferenceKeyTileState extends State<_PreferenceKeyTile> {
         setState(() {
           _isExpanded = expanded;
         });
+        widget.onExpansionChanged(expanded);
       },
       children: [
         if (value is bool)
@@ -927,7 +1013,12 @@ class _PreferenceKeyTileState extends State<_PreferenceKeyTile> {
       return _JsonEditor(
         keyName: widget.keyName,
         initialText: const JsonEncoder.withIndent('  ').convert(decoded),
-        onSave: (formatted) => widget.onChanged(formatted),
+        draft: widget.draft,
+        onDraftChanged: widget.onDraftChanged,
+        onSave: (formatted) {
+          widget.onDraftChanged(null);
+          widget.onChanged(formatted);
+        },
       );
     } else {
       return ListTile(
@@ -947,9 +1038,16 @@ class _JsonEditor extends StatefulWidget {
   final String initialText;
   final ValueChanged<String> onSave;
 
+  /// In-progress edit owned by the parent, so it survives this editor being
+  /// unmounted when the surrounding lazy lists scroll it out of view.
+  final String? draft;
+  final ValueChanged<String?> onDraftChanged;
+
   const _JsonEditor({
     required this.keyName,
     required this.initialText,
+    required this.draft,
+    required this.onDraftChanged,
     required this.onSave,
   });
 
@@ -965,7 +1063,22 @@ class _JsonEditorState extends State<_JsonEditor> {
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController(text: widget.initialText);
+    _controller =
+        TextEditingController(text: widget.draft ?? widget.initialText);
+    _controller.addListener(_reportDraft);
+  }
+
+  void _reportDraft() {
+    widget.onDraftChanged(
+      _controller.text == widget.initialText ? null : _controller.text,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_reportDraft);
+    _controller.dispose();
+    super.dispose();
   }
 
   void _formatJson() {

--- a/lib/widgets/preferences.dart
+++ b/lib/widgets/preferences.dart
@@ -619,7 +619,10 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget>
   // every row from scratch. Anything the user has typed must therefore live
   // above both lists to survive.
   final Map<String, String> _drafts = {};
-  String? _expandedKey;
+
+  // A set, not a single key: rows expand independently, so collapsing one on
+  // remount because another was opened would be a regression.
+  final Set<String> _expandedKeys = {};
 
   // Keeps this section itself mounted when the page scrolls past it, which is
   // what makes _drafts a safe place to keep that state (and avoids reloading
@@ -734,7 +737,7 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget>
                         keyName: e.key,
                         value: e.value,
                         isInDatabase: dbFlags[e.key] ?? false,
-                        initiallyExpanded: _expandedKey == e.key,
+                        initiallyExpanded: _expandedKeys.contains(e.key),
                         draft: _drafts[e.key],
                         // No setState: the row already holds this text in
                         // its own controller, and rebuilding the list on
@@ -747,7 +750,11 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget>
                           }
                         },
                         onExpansionChanged: (expanded) {
-                          _expandedKey = expanded ? e.key : null;
+                          if (expanded) {
+                            _expandedKeys.add(e.key);
+                          } else {
+                            _expandedKeys.remove(e.key);
+                          }
                         },
                         onChanged: (newValue) async {
                           final isInDb = dbFlags[e.key] ?? false;
@@ -800,7 +807,7 @@ class _PreferencesKeysWidgetState extends ConsumerState<PreferencesKeysWidget>
                               await localPrefs.remove(e.key);
                             }
                             _drafts.remove(e.key);
-                            if (_expandedKey == e.key) _expandedKey = null;
+                            _expandedKeys.remove(e.key);
                             // Reload data and invalidate provider
                             _loading = true;
                             _loadData(prefs);

--- a/test/widgets/preferences_scroll_state_test.dart
+++ b/test/widgets/preferences_scroll_state_test.dart
@@ -182,6 +182,46 @@ void main() {
           reason: 'unsaved edit was discarded when scrolling above the '
               'preferences keys section');
     });
+
+    testWidgets('two rows stay expanded independently across a scroll',
+        (tester) async {
+      // Rows expand independently, so opening a second one must not collapse
+      // the first when the list is rebuilt.
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _wrap(const SizedBox(height: 600, child: PreferencesKeysWidget())),
+      );
+      await tester.pumpAndSettle();
+
+      // Open the first two rows. Note .first must come after .descendant:
+      // find.byType(Text).first would resolve globally before filtering.
+      Finder titleOf(int i) => find
+          .descendant(
+              of: find.byType(ExpansionTile).at(i), matching: find.byType(Text))
+          .first;
+      await tester.tap(titleOf(0));
+      await tester.pumpAndSettle();
+      await tester.tap(titleOf(1));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsNWidgets(2),
+          reason: 'both rows should be open at once');
+
+      // Force a rebuild of the rows by scrolling away and back.
+      final at = _positionAt(tester, 0);
+      final offset = at.pixels;
+      at.jumpTo(at.maxScrollExtent);
+      await tester.pumpAndSettle();
+      _positionAt(tester, 0).jumpTo(offset);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsNWidgets(2),
+          reason: 'opening the second row must not collapse the first');
+    });
   });
 
   _deleteDialogTests();

--- a/test/widgets/preferences_scroll_state_test.dart
+++ b/test/widgets/preferences_scroll_state_test.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:tfc/providers/database.dart';
+import 'package:tfc/providers/preferences.dart';
+import 'package:tfc/widgets/preferences.dart';
+import 'package:tfc_dart/core/preferences.dart';
+
+import '../helpers/test_helpers.dart';
+
+/// Regression tests: editing a preference value and then scrolling the entry
+/// out of view must not discard the unsaved edit.
+///
+/// The preferences UI nests two lazy scrollables:
+///
+///   PreferencesPage        ListView          (outer, page level)
+///     +- SizedBox(600)
+///          +- PreferencesKeysWidget
+///               +- ListView                  (inner, one row per pref key)
+///                    +- _PreferenceKeyTile   the editor lives in here
+///
+/// Both unmount children scrolled past the cache extent, disposing their
+/// State — and re-attaching the section rebuilds every row from scratch. So
+/// the in-progress text has to be held above both lists to survive.
+///
+/// A focused TextField pins its own row alive (EditableText requests
+/// keep-alive while focused), which masks the bug: these tests drop focus
+/// first, as tapping anywhere else in the UI would.
+///
+/// (The outer ListView + SizedBox(600) layout is itself the Bug 9 overflow
+/// fix — see test/pages/preferences_test.dart. This is its side effect.)
+
+/// Sorts into the middle of the key list, so it can be scrolled *above* as
+/// well as below — matching the reported symptom.
+const _jsonKey = 'm_page_editor';
+const _fillerCount = 40;
+
+Future<Preferences> _seededPreferences() async {
+  final prefs = Preferences(database: null, secureStorage: FakeSecureStorage());
+  await prefs.setString(_jsonKey, jsonEncode({'pages': [], 'version': 1}));
+  for (var i = 0; i < _fillerCount; i++) {
+    final n = i.toString().padLeft(2, '0');
+    // Half sort before the JSON key, half after.
+    await prefs.setString(i.isEven ? 'a_filler_$n' : 'z_filler_$n', 'value $i');
+  }
+  return prefs;
+}
+
+/// One instance per test: invalidating the provider must resolve to the *same*
+/// Preferences, or a delete would be undone by re-seeding. Created lazily on
+/// first read so it lives inside the test's async zone.
+Future<Preferences>? _prefs;
+
+Widget _wrap(Widget child) {
+  return ProviderScope(
+    overrides: [
+      preferencesProvider
+          .overrideWith((ref) => _prefs ??= _seededPreferences()),
+      databaseProvider.overrideWith((ref) async => null),
+    ],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+ScrollPosition _positionAt(WidgetTester tester, int index) =>
+    tester.state<ScrollableState>(find.byType(Scrollable).at(index)).position;
+
+/// Expands the JSON pref row, replaces the editor contents, then drops focus.
+Future<void> _editJsonAndUnfocus(WidgetTester tester, String newText) async {
+  await tester.tap(find.textContaining(_jsonKey));
+  await tester.pumpAndSettle();
+
+  // Only the expanded row has a TextField; the rest are collapsed.
+  final field = find.byType(TextField);
+  expect(field, findsOneWidget,
+      reason: 'expanded JSON pref row should expose exactly one editor');
+
+  await tester.enterText(field, newText);
+  await tester.pumpAndSettle();
+  expect(find.text(newText), findsOneWidget);
+
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+    _prefs = null;
+  });
+
+  group('unsaved preference edits survive scrolling', () {
+    testWidgets('key list: scroll up above the edited row and back',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _wrap(const SizedBox(height: 600, child: PreferencesKeysWidget())),
+      );
+      await tester.pumpAndSettle();
+
+      // Scroll down to the mid-list JSON key.
+      await tester.scrollUntilVisible(
+        find.textContaining(_jsonKey),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      final offset = _positionAt(tester, 0).pixels;
+
+      const edited = '{"pages": [], "version": 1234}';
+      await _editJsonAndUnfocus(tester, edited);
+
+      // Scroll up above the edited row, far enough to unmount it.
+      _positionAt(tester, 0).jumpTo(0);
+      await tester.pumpAndSettle();
+      expect(find.text(edited), findsNothing,
+          reason: 'edited row should be scrolled out of view');
+
+      _positionAt(tester, 0).jumpTo(offset);
+      await tester.pumpAndSettle();
+
+      expect(find.text(edited), findsOneWidget,
+          reason: 'unsaved edit was discarded when the row scrolled offscreen');
+    });
+
+    testWidgets('page list: scroll above the keys section and back',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      // Mirrors PreferencesPage: a tall section above the fixed-height keys
+      // section, all inside the page-level ListView.
+      await tester.pumpWidget(
+        _wrap(
+          ListView(
+            children: const [
+              SizedBox(height: 900, child: Placeholder()),
+              SizedBox(height: 600, child: PreferencesKeysWidget()),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Scrollable 0 is the page list, 1 is the key list. Drive them by
+      // position: a drag would go to whichever is innermost under the pointer.
+      _positionAt(tester, 0).jumpTo(900);
+      await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.textContaining(_jsonKey),
+        200,
+        scrollable: find.byType(Scrollable).at(1),
+      );
+      await tester.pumpAndSettle();
+
+      const edited = '{"pages": [], "version": 4242}';
+      await _editJsonAndUnfocus(tester, edited);
+
+      // Scroll the whole section out of view, then back to it.
+      _positionAt(tester, 0).jumpTo(0);
+      await tester.pumpAndSettle();
+
+      _positionAt(tester, 0).jumpTo(900);
+      await tester.pumpAndSettle();
+
+      expect(find.text(edited), findsOneWidget,
+          reason: 'unsaved edit was discarded when scrolling above the '
+              'preferences keys section');
+    });
+  });
+
+  _deleteDialogTests();
+}
+
+/// The delete confirmation is used repeatedly when clearing out stale keys,
+/// so the Delete button takes focus on open and Enter confirms it.
+///
+/// Confirming is observed through the local store rather than the rendered
+/// list: the row is labelled "(Local)", so the dialog's confirm branch calls
+/// remove() on SharedPreferences. Dismissing must leave it untouched.
+void _deleteDialogTests() {
+  group('delete preference confirmation', () {
+    /// Opens the confirmation for the first row and returns its key.
+    Future<String> openDeleteDialog(WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(const SizedBox(height: 600, child: PreferencesKeysWidget())),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(FontAwesomeIcons.trash.data).first);
+      await tester.pumpAndSettle();
+      expect(find.text('Delete Preference'), findsOneWidget);
+
+      final prompt = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data)
+          .whereType<String>()
+          .firstWhere((s) => s.startsWith('Delete "'));
+      final key = RegExp(r'Delete "(.+)"\?').firstMatch(prompt)!.group(1)!;
+
+      // Mirror the row into the local store so the confirm branch has
+      // something observable to remove.
+      await SharedPreferencesAsync().setString(key, 'seeded');
+      return key;
+    }
+
+    testWidgets('Enter confirms the delete', (tester) async {
+      final key = await openDeleteDialog(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete Preference'), findsNothing,
+          reason: 'Enter should activate the focused Delete button');
+      expect(await SharedPreferencesAsync().containsKey(key), isFalse,
+          reason: 'Enter should confirm, not merely dismiss, the dialog');
+    });
+
+    testWidgets('Escape dismisses without deleting', (tester) async {
+      final key = await openDeleteDialog(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete Preference'), findsNothing);
+      expect(await SharedPreferencesAsync().containsKey(key), isTrue,
+          reason: 'Escape must not delete anything');
+    });
+  });
+}


### PR DESCRIPTION
Editing a preference value and then scrolling the entry out of view silently discarded the edit.

## Cause

The preferences UI nests two lazy scrollables:

```
PreferencesPage        ListView          (page level)
  └─ SizedBox(600)
       └─ PreferencesKeysWidget
            └─ ListView                  (one row per preference key)
                 └─ _PreferenceKeyTile   ← the editor lived here
```

Both unmount children scrolled past the cache extent, disposing their `State`. The in-progress text lived in a `TextEditingController` owned by that `State`, so it went with it.

Keeping the *row* alive is not sufficient — the teardown happens a level above it. Instrumenting the re-attach confirmed **every row's `State` is a new object** afterwards. So the two pieces of transient state (which row is open, and the unsaved text per key) move up into `PreferencesKeysWidget`, which is itself pinned with `AutomaticKeepAliveClientMixin` so the page-level list cannot drop it. That also avoids reloading every preference value on the way back.

> [!NOTE]
> **Why this looked intermittent.** A focused `TextField` pins its own row alive — `EditableText` requests keep-alive while it has focus. Scrolling with the cursor still in the editor preserved the edit; clicking elsewhere first lost it. The regression tests drop focus explicitly, and an early version of one test accidentally kept focus and passed against the *unfixed* code.

## Supporting changes

These were required, not cosmetic:

| Change | Why |
|---|---|
| `ListView` → `ListView.builder` for the key list | `ListView(children:)` constructs every row up front, so a re-mounted row reused a widget still carrying the draft/expansion captured at the parent's last build — i.e. before anything was typed. This silently defeated the first version of the fix. Also lazier for long key lists. |
| `ValueKey(key)` per row | `State` follows the preference rather than the list position when keys are added or removed. |
| Dispose controllers in `_PreferenceKeyTile` / `_JsonEditor` | Neither did before — a pre-existing leak, and now required since listeners are attached. |

## Enter confirms delete

The delete confirmation autofocuses its Delete button, so <kbd>Enter</kbd> confirms it when clearing out several keys in a row. <kbd>Escape</kbd> still dismisses without deleting.

> [!WARNING]
> This makes a destructive action the keyboard default — a stray <kbd>Enter</kbd> while the dialog is open will delete. Requested deliberately to speed up bulk cleanup.

## Verification

4 new tests in `test/widgets/preferences_scroll_state_test.dart`, driving the real `PreferencesKeysWidget`:

- key list: scroll up above the edited row and back
- page list: scroll above the keys section and back
- Enter confirms the delete
- Escape dismisses without deleting

Each was checked to **fail without the fix and pass with it** (re-run against stashed source, not assumed). The delete tests observe the local store rather than the rendered list, so they distinguish confirming from merely dismissing.

Full suite: **2168/2168 passing**.

## Found but not fixed

Deleting a `(Local)` key appears broken independently of this change: `Preferences.setString` writes to an internal `_memoryCache`, but the delete path calls `remove()` on `SharedPreferences` only, and `_loadData` then re-reads `_memoryCache` — so the key reappears. The tests here work around it by asserting against the store directly. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)