### PR TITLE
feat(page-editor): send an asset to the back from the right-click menu

### DIFF
--- a/lib/chat/ai_context_action.dart
+++ b/lib/chat/ai_context_action.dart
@@ -200,7 +200,19 @@ class AiContextAction {
 
     if (result == null) return null;
 
-    final item = menuItems[result];
+    return runMenuItem(ref: ref, item: menuItems[result]);
+  }
+
+  /// Opens chat for a single [item], as if it had been picked from the menu
+  /// shown by [showMenuAndChat].
+  ///
+  /// Exposed so callers that build their own menu — the page editor mixes AI
+  /// actions with plain editing actions in one popup — can dispatch an
+  /// [AiMenuItem] without duplicating this logic.
+  static Future<bool?> runMenuItem({
+    required WidgetRef ref,
+    required AiMenuItem item,
+  }) async {
     if (item.sendImmediately) {
       return openChatAndSend(ref: ref, message: item.prefillText);
     } else {

--- a/lib/pages/page_editor.dart
+++ b/lib/pages/page_editor.dart
@@ -597,6 +597,11 @@ class _PageEditorState extends ConsumerState<PageEditor> {
     );
 
     if (choice == null) return;
+    // The editor can be torn down while the menu is open — proposal events
+    // arriving over MCP navigate on their own — and both branches below touch
+    // State (setState / ref) that is invalid after dispose.
+    if (!mounted) return;
+
     if (choice == _sendToBackAction) {
       _sendToBack(targets);
     } else {

--- a/lib/pages/page_editor.dart
+++ b/lib/pages/page_editor.dart
@@ -17,6 +17,8 @@ import '../tech_docs/tech_doc_picker.dart';
 
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import '../chat/ai_context_action.dart';
+import '../chat/asset_context_menu.dart' show buildEditorAssetMenuItems;
+import '../providers/mcp_bridge.dart' show isMcpChatAvailable;
 import '../chat/chat_overlay.dart' show ChatContext;
 import '../chat/hamburger_context_menu.dart';
 import '../chat/page_context_menu.dart';
@@ -55,6 +57,40 @@ bool marqueeHitTestRotatedAsset({
   final localDx = dx * cosA - dy * sinA;
   final localDy = dx * sinA + dy * cosA;
   return localDx.abs() <= halfW && localDy.abs() <= halfH;
+}
+
+/// Reorders [assets] so that [targets] sit beneath everything else.
+///
+/// Paint order is list order — `AssetStack` renders assets in sequence, so the
+/// head of the list is the back of the stack. Members of [targets] keep their
+/// own relative stacking; only their position relative to the rest changes.
+///
+/// Returns a new list; [assets] is not modified. Generic so the ordering can
+/// be tested without building real assets.
+@visibleForTesting
+List<T> sendToBackOrder<T>(List<T> assets, Set<T> targets) {
+  final moving = <T>[];
+  final rest = <T>[];
+  for (final asset in assets) {
+    (targets.contains(asset) ? moving : rest).add(asset);
+  }
+  return [...moving, ...rest];
+}
+
+/// Whether [targets] already occupy the back of the stack, i.e. the leading
+/// run of [assets]. Empty or absent targets count as already-at-back, since
+/// there is nothing to move.
+@visibleForTesting
+bool isAlreadyAtBack<T>(List<T> assets, Set<T> targets) {
+  var seen = 0;
+  for (var i = 0; i < assets.length; i++) {
+    if (targets.contains(assets[i])) {
+      // Out of the leading run: something else is already below it.
+      if (i != seen) return false;
+      seen++;
+    }
+  }
+  return true;
 }
 
 /// Projects a drag delta from the rotated GestureDetector's local frame
@@ -482,6 +518,92 @@ class _PageEditorState extends ConsumerState<PageEditor> {
     });
   }
 
+  /// Menu value for "send to back"; AI entries use their own list index, so
+  /// this sits outside that range.
+  static const int _sendToBackAction = -1;
+
+  /// Assets a canvas action applies to: the whole selection when the asset
+  /// acted on is part of it, otherwise just that asset. Mirrors [_moveAsset].
+  List<Asset> _actionTargets(Asset asset) =>
+      _selectedAssets.contains(asset) ? _selectedAssets.toList() : [asset];
+
+  /// False when [targets] already sit at the bottom, so the menu entry can be
+  /// disabled rather than pushing a no-op onto the undo history.
+  bool _canSendToBack(List<Asset> targets) =>
+      !isAlreadyAtBack(assets, targets.toSet());
+
+  /// Moves [targets] beneath every other asset on the page.
+  void _sendToBack(List<Asset> targets) {
+    final moving = targets.toSet();
+    if (isAlreadyAtBack(assets, moving)) return;
+
+    _saveToHistory();
+    setState(() {
+      final reordered = sendToBackOrder(assets, moving);
+      // Mutate in place: AssetPage holds a reference to this same list.
+      assets
+        ..clear()
+        ..addAll(reordered);
+      _updateCurrentJson();
+    });
+  }
+
+  /// Right-click menu for an asset on the canvas.
+  ///
+  /// Editing actions are always available; the AI entries are appended only
+  /// when MCP chat is up, preserving what the AI-only menu used to offer.
+  Future<void> _showAssetContextMenu(Asset asset, Offset globalPosition) async {
+    final aiItems = isMcpChatAvailable()
+        ? buildEditorAssetMenuItems(asset)
+        : const <AiMenuItem>[];
+
+    final targets = _actionTargets(asset);
+    final canSendToBack = _canSendToBack(targets);
+
+    final choice = await showMenu<int>(
+      context: context,
+      useRootNavigator: true,
+      clipBehavior: Clip.antiAlias,
+      position: RelativeRect.fromLTRB(
+        globalPosition.dx,
+        globalPosition.dy,
+        globalPosition.dx,
+        globalPosition.dy,
+      ),
+      items: [
+        PopupMenuItem<int>(
+          value: _sendToBackAction,
+          enabled: canSendToBack,
+          child: ListTile(
+            leading: const Icon(Icons.flip_to_back),
+            title: Text(targets.length > 1
+                ? 'Send ${targets.length} assets to back'
+                : 'Send to back'),
+            dense: true,
+            enabled: canSendToBack,
+          ),
+        ),
+        if (aiItems.isNotEmpty) const PopupMenuDivider(),
+        for (var i = 0; i < aiItems.length; i++)
+          PopupMenuItem<int>(
+            value: i,
+            child: ListTile(
+              leading: Icon(aiItems[i].icon),
+              title: Text(aiItems[i].label),
+              dense: true,
+            ),
+          ),
+      ],
+    );
+
+    if (choice == null) return;
+    if (choice == _sendToBackAction) {
+      _sendToBack(targets);
+    } else {
+      await AiContextAction.runMenuItem(ref: ref, item: aiItems[choice]);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // Reactively watch for new page/asset proposals arriving via MCP.
@@ -640,6 +762,7 @@ class _PageEditorState extends ConsumerState<PageEditor> {
                             onPanStart: (asset, details) {
                               _saveToHistory();
                             },
+                            onSecondaryTap: _showAssetContextMenu,
                             absorb: true,
                             selectedAssets: _selectedAssets,
                             proposedAssets: _proposedAssets,

--- a/lib/pages/page_view.dart
+++ b/lib/pages/page_view.dart
@@ -118,6 +118,11 @@ class AssetStack extends ConsumerStatefulWidget {
   final void Function(Asset asset)? onTap;
   final void Function(Asset asset, DragUpdateDetails details)? onPanUpdate;
   final void Function(Asset asset, DragStartDetails details)? onPanStart;
+
+  /// Secondary tap (right-click) on an asset in edit mode. When supplied the
+  /// host builds the whole context menu, so it can offer editing actions
+  /// alongside the AI ones. Falls back to the AI-only menu when null.
+  final void Function(Asset asset, Offset globalPosition)? onSecondaryTap;
   final bool absorb;
   final Set<Asset> selectedAssets;
   final bool mirroringDisabled;
@@ -133,6 +138,7 @@ class AssetStack extends ConsumerStatefulWidget {
     this.onTap,
     this.onPanUpdate,
     this.onPanStart,
+    this.onSecondaryTap,
     this.absorb = false,
     required this.selectedAssets,
     required this.mirroringDisabled,
@@ -350,16 +356,26 @@ class _AssetStackState extends ConsumerState<AssetStack> {
                                     ? (details) =>
                                         widget.onPanStart!(asset, details)
                                     : null,
-                                onSecondaryTapUp: isMcpChatAvailable()
-                                    ? (details) {
-                                        showEditorAssetContextMenu(
-                                          context,
-                                          ref,
-                                          details.globalPosition,
+                                // The host's menu wins when supplied: it
+                                // carries editing actions that must be
+                                // reachable whether or not MCP chat is
+                                // available, and folds the AI entries in
+                                // itself.
+                                onSecondaryTapUp: widget.onSecondaryTap != null
+                                    ? (details) => widget.onSecondaryTap!(
                                           asset,
-                                        );
-                                      }
-                                    : null,
+                                          details.globalPosition,
+                                        )
+                                    : isMcpChatAvailable()
+                                        ? (details) {
+                                            showEditorAssetContextMenu(
+                                              context,
+                                              ref,
+                                              details.globalPosition,
+                                              asset,
+                                            );
+                                          }
+                                        : null,
                               )
                             : GestureDetector(
                                 // Runtime view: only secondary tap is

--- a/test/pages/page_editor_send_to_back_test.dart
+++ b/test/pages/page_editor_send_to_back_test.dart
@@ -130,14 +130,25 @@ class _TestBoxAsset extends BaseAsset {
 
   final String name;
 
-  _TestBoxAsset(this.name, {required Coordinates coords}) {
+  /// Mirrors production assets that wrap their visual in their own
+  /// GestureDetector; used to prove a tap coordinate is really on the asset.
+  final VoidCallback? onInternalTap;
+
+  _TestBoxAsset(this.name, {required Coordinates coords, this.onInternalTap}) {
     coordinates = coords;
     size = const RelativeSize(width: 0.2, height: 0.2);
   }
 
   @override
-  Widget build(BuildContext context) =>
-      const ColoredBox(color: Color(0xFFFF0000));
+  Widget build(BuildContext context) {
+    const visual = ColoredBox(color: Color(0xFFFF0000));
+    if (onInternalTap == null) return visual;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onInternalTap,
+      child: visual,
+    );
+  }
 
   @override
   Widget configure(BuildContext context) => const SizedBox.shrink();
@@ -149,6 +160,7 @@ class _TestBoxAsset extends BaseAsset {
 Widget _wrapStack({
   required List<Asset> assets,
   void Function(Asset, Offset)? onSecondaryTap,
+  bool absorb = true,
 }) {
   return ProviderScope(
     child: MaterialApp(
@@ -164,8 +176,7 @@ Widget _wrapStack({
                 selectedAssets: const {},
                 mirroringDisabled: true,
                 onSecondaryTap: onSecondaryTap,
-                // Edit mode — the only mode that offers editing actions.
-                absorb: true,
+                absorb: absorb,
               ),
             ),
           ),
@@ -213,6 +224,39 @@ void _secondaryTapTests() {
 
       expect(taps, ['right'],
           reason: 'host callback should receive the right-clicked asset');
+    });
+
+    testWidgets('is ignored in runtime mode', (tester) async {
+      // Runtime mode is the operator-facing path, where secondary tap belongs
+      // to the debug/chat menu. A host callback must not silently take it
+      // over and change what operators get.
+      var internalTaps = 0;
+      final asset = _TestBoxAsset(
+        'a',
+        coords: Coordinates(x: 0.5, y: 0.5),
+        onInternalTap: () => internalTaps++,
+      );
+
+      final taps = <String>[];
+      await tester.pumpWidget(_wrapStack(
+        assets: [asset],
+        absorb: false,
+        onSecondaryTap: (a, _) => taps.add('fired'),
+      ));
+      await tester.pumpAndSettle();
+
+      final point = _pointOn(tester, 0.5, 0.5);
+      // Prove the coordinate is on the asset, so the secondary-tap assertion
+      // below is a real result rather than a miss.
+      await tester.tapAt(point);
+      await tester.pumpAndSettle();
+      expect(internalTaps, 1, reason: 'coordinate should be on the asset');
+
+      await tester.tapAt(point, buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+
+      expect(taps, isEmpty,
+          reason: 'onSecondaryTap is documented as edit-mode only');
     });
 
     testWidgets('does not fire on a primary tap', (tester) async {

--- a/test/pages/page_editor_send_to_back_test.dart
+++ b/test/pages/page_editor_send_to_back_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:tfc/page_creator/assets/common.dart';
+import 'package:tfc/pages/page_editor.dart';
+import 'package:tfc/pages/page_view.dart';
+
+/// Z-order in the page editor is list order: `AssetStack` renders
+/// `AssetPage.assets` in sequence, so the head of the list is the back of the
+/// stack. "Send to back" therefore moves the selection to the head.
+///
+/// These cover the ordering itself; the helpers are generic so the algorithm
+/// can be exercised without building real assets.
+void main() {
+  group('sendToBackOrder', () {
+    test('moves a single asset to the head', () {
+      expect(sendToBackOrder(['a', 'b', 'c'], {'c'}), ['c', 'a', 'b']);
+    });
+
+    test('leaves an asset already at the back alone', () {
+      expect(sendToBackOrder(['a', 'b', 'c'], {'a'}), ['a', 'b', 'c']);
+    });
+
+    test('preserves relative order within the selection', () {
+      // b before d in the input, so b stays before d in the result.
+      expect(
+        sendToBackOrder(['a', 'b', 'c', 'd'], {'d', 'b'}),
+        ['b', 'd', 'a', 'c'],
+      );
+    });
+
+    test('preserves relative order of the assets left behind', () {
+      expect(
+        sendToBackOrder(['a', 'b', 'c', 'd', 'e'], {'c'}),
+        ['c', 'a', 'b', 'd', 'e'],
+      );
+    });
+
+    test('handles a non-contiguous selection', () {
+      expect(
+        sendToBackOrder(['a', 'b', 'c', 'd', 'e'], {'a', 'c', 'e'}),
+        ['a', 'c', 'e', 'b', 'd'],
+      );
+    });
+
+    test('moving everything is a no-op', () {
+      expect(sendToBackOrder(['a', 'b'], {'a', 'b'}), ['a', 'b']);
+    });
+
+    test('ignores targets that are not on the page', () {
+      expect(sendToBackOrder(['a', 'b'], {'zz'}), ['a', 'b']);
+    });
+
+    test('does not modify the input list', () {
+      final input = ['a', 'b', 'c'];
+      sendToBackOrder(input, {'c'});
+      expect(input, ['a', 'b', 'c']);
+    });
+  });
+
+  group('isAlreadyAtBack', () {
+    test('true for the bottom-most asset', () {
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'a'}), isTrue);
+    });
+
+    test('false for anything above it', () {
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'b'}), isFalse);
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'c'}), isFalse);
+    });
+
+    test('true for a contiguous run at the back', () {
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'a', 'b'}), isTrue);
+    });
+
+    test('false when the run is contiguous but not at the back', () {
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'b', 'c'}), isFalse);
+    });
+
+    test('false for a non-contiguous selection touching the back', () {
+      expect(isAlreadyAtBack(['a', 'b', 'c'], {'a', 'c'}), isFalse);
+    });
+
+    test('true when every asset is selected', () {
+      expect(isAlreadyAtBack(['a', 'b'], {'a', 'b'}), isTrue);
+    });
+
+    test('true for an empty selection — nothing to move', () {
+      expect(isAlreadyAtBack(['a', 'b'], <String>{}), isTrue);
+    });
+
+    test('true for an empty page', () {
+      expect(isAlreadyAtBack(<String>[], {'a'}), isTrue);
+    });
+
+    test('agrees with sendToBackOrder being a no-op', () {
+      // The predicate exists to disable the menu entry, so it must be exactly
+      // the cases where reordering would change nothing.
+      const page = ['a', 'b', 'c', 'd'];
+      for (final targets in [
+        {'a'},
+        {'b'},
+        {'c'},
+        {'a', 'b'},
+        {'b', 'c'},
+        {'a', 'c'},
+        {'a', 'b', 'c', 'd'},
+        <String>{},
+      ]) {
+        final unchanged =
+            sendToBackOrder(page, targets).toString() == page.toString();
+        expect(isAlreadyAtBack(page, targets), unchanged,
+            reason: 'mismatch for targets $targets');
+      }
+    });
+  });
+
+  _secondaryTapTests();
+}
+
+/// Minimal asset so the stack can be driven without real PLC state.
+class _TestBoxAsset extends BaseAsset {
+  @override
+  String get displayName => 'TestBox';
+  @override
+  String get category => 'Test';
+
+  final String name;
+
+  _TestBoxAsset(this.name, {required Coordinates coords}) {
+    coordinates = coords;
+    size = const RelativeSize(width: 0.2, height: 0.2);
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      const ColoredBox(color: Color(0xFFFF0000));
+
+  @override
+  Widget configure(BuildContext context) => const SizedBox.shrink();
+
+  @override
+  Map<String, dynamic> toJson() => {constAssetName: 'TestBoxAsset'};
+}
+
+Widget _wrapStack({
+  required List<Asset> assets,
+  void Function(Asset, Offset)? onSecondaryTap,
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 400,
+            height: 400,
+            child: LayoutBuilder(
+              builder: (context, constraints) => AssetStack(
+                assets: assets,
+                constraints: constraints,
+                selectedAssets: const {},
+                mirroringDisabled: true,
+                onSecondaryTap: onSecondaryTap,
+                // Edit mode — the only mode that offers editing actions.
+                absorb: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/// A point at relative ([fx], [fy]) within the rendered stack.
+Offset _pointOn(WidgetTester tester, double fx, double fy) {
+  final r = tester.getRect(find.byType(AssetStack));
+  return Offset(r.left + r.width * fx, r.top + r.height * fy);
+}
+
+/// Guards the wiring the unit tests above cannot reach: the host-supplied
+/// context menu must take precedence over the AI-only one, so "Send to back"
+/// is reachable whether or not MCP chat is available.
+void _secondaryTapTests() {
+  group('AssetStack secondary tap', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+    });
+
+    testWidgets('right-click in edit mode reports the asset to the host',
+        (tester) async {
+      final left = _TestBoxAsset('left', coords: Coordinates(x: 0.25, y: 0.5));
+      final right =
+          _TestBoxAsset('right', coords: Coordinates(x: 0.75, y: 0.5));
+
+      final taps = <String>[];
+      await tester.pumpWidget(_wrapStack(
+        assets: [left, right],
+        onSecondaryTap: (asset, _) => taps.add((asset as _TestBoxAsset).name),
+      ));
+      await tester.pumpAndSettle();
+
+      // Compute from the real rect: the stack is centred in the test window,
+      // so hard-coded offsets would miss (and silently pass).
+      await tester.tapAt(_pointOn(tester, 0.75, 0.5),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+
+      expect(taps, ['right'],
+          reason: 'host callback should receive the right-clicked asset');
+    });
+
+    testWidgets('does not fire on a primary tap', (tester) async {
+      final asset = _TestBoxAsset('a', coords: Coordinates(x: 0.5, y: 0.5));
+
+      final taps = <String>[];
+      await tester.pumpWidget(_wrapStack(
+        assets: [asset],
+        onSecondaryTap: (a, _) => taps.add('fired'),
+      ));
+      await tester.pumpAndSettle();
+
+      final point = _pointOn(tester, 0.5, 0.5);
+      // Sanity: a secondary tap here *does* land on the asset, so the primary
+      // tap below is a real miss rather than a mis-aimed one.
+      await tester.tapAt(point, buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      expect(taps, ['fired'], reason: 'coordinate should be on the asset');
+      taps.clear();
+
+      await tester.tapAt(point);
+      await tester.pumpAndSettle();
+
+      expect(taps, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Adds a **Send to back** action to the page editor, reachable by right-clicking an asset on the canvas.

## Z-order needed no new machinery

`AssetStack` renders `AssetPage.assets` in sequence, so the head of the list **is** the back of the stack. Send-to-back is therefore a move to index 0 — **no z-index field, no schema change, no migration**. Ordering already round-trips through the existing JSON.

## Why the context menu had to change

The canvas already had an `onSecondaryTapUp` handler, but it was gated behind `isMcpChatAvailable()` and went straight into `AiContextAction.showMenuAndChat` — which early-returns when MCP is down and treats every entry as "open chat". An editing action has to be reachable regardless, so the editor now builds its own menu.

| Change | Effect |
|---|---|
| `AssetStack` gains optional `onSecondaryTap(asset, globalPosition)` | When supplied it wins; otherwise the previous AI-only path is left **exactly** as it was, so runtime mode and other callers are unaffected. |
| Editor builds the menu | "Send to back" always present; the existing *Configure with AI* / *Explain asset type* entries are appended when MCP is available, so **nothing is lost when chat is on**. |
| Extract `AiContextAction.runMenuItem` from the tail of `showMenuAndChat` | Lets the editor dispatch an `AiMenuItem` without duplicating the `ChatContext` construction. No behaviour change. |

## Behaviour

- Acts on the whole selection when the clicked asset is part of it, otherwise just that asset — the same rule as `_moveAsset`.
- The selection keeps its own relative stacking; only its position relative to everything else changes.
- **Disabled, not a no-op**, when the targets already sit at the back, so it cannot push an empty entry onto the undo history.
- Pushes an undo snapshot via `_saveToHistory`, so <kbd>Ctrl</kbd>+<kbd>Z</kbd> reverts it.

## Tests

19 tests. The ordering is extracted into two generic `@visibleForTesting` helpers (`sendToBackOrder`, `isAlreadyAtBack`) matching the existing helpers in this file, so the algorithm is exercised directly rather than through the editor's provider chain — including non-contiguous selections, and a check that the disabled-state predicate agrees *exactly* with "reordering changes nothing".

> [!NOTE]
> My first pass at the widget tests **passed vacuously**: hard-coded tap coordinates missed the asset entirely, because the 400×400 stack is centred in an 800×600 test window. Both now compute the point from the real rect, and the "primary tap does not fire" test first confirms via a secondary tap that the coordinate genuinely lands on the asset.

Full suite: **2188/2188**. `flutter analyze lib/` clean.

## Known gap

> [!WARNING]
> Right-click has no touch equivalent. If the page editor is ever used on HMI panel hardware rather than a desktop, this action is unreachable. Long-press would cover it, but needs care against the existing pan gesture — deliberately left out of this PR.

Also, by design this ships **without** an inverse: once an asset is at the back, the only way to raise it is to send the others back too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)