### PR TITLE
fix(ci): keep the msix out of the portable Windows zip

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -108,6 +108,11 @@ jobs:
           foreach ($dll in "msvcp140.dll", "vcruntime140.dll", "vcruntime140_1.dll") {
             Copy-Item "C:\Windows\System32\$dll" $release
           }
+          # msix:create drops the package here, so it would otherwise ride
+          # along inside the portable zip — 26 MB of installer in a download
+          # whose whole point is not being an installer. Already uploaded as
+          # its own artifact by this point.
+          Remove-Item "$release/*.msix" -Force -ErrorAction SilentlyContinue
           Get-ChildItem $release
 
       - name: Upload portable exe artifact


### PR DESCRIPTION
Follow-up to #133. The published `centroidx_windows_x64.zip` contains `centroidx.msix`.

`dart run msix:create` writes the package into `build/windows/x64/runner/Release/`, which is exactly the folder the portable artifact is uploaded from — so the installer rode along inside the zip that exists specifically to not be an installer.

Verified against the published asset:

```
$ unzip -Zl centroidx_windows_x64.zip | grep -E "msix|centroidx.exe"
 26352351  centroidx-windows-x64/centroidx.msix
    76800  centroidx-windows-x64/centroidx.exe
```

26 MB of a 49 MB download.

The MSIX is removed from the Release folder after it has already been uploaded as its own artifact, so tagged releases still ship it unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)