### PR TITLE
fix(windows): recover from GPU device loss instead of freezing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,3 +165,27 @@ jobs:
           packages/tfc_dart/coverage/
           packages/tfc_dart/test-results/
         retention-days: 30
+
+  # Windows runner C++ unit tests. The code under test (the GPU device-loss
+  # watchdog state machine) is deliberately free of Win32 and Flutter types, so
+  # it builds and runs on every platform — no Windows runner or GPU needed.
+  windows-runner-cpp-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure
+      working-directory: centroid-hmi/windows/runner/test
+      run: cmake -S . -B build
+
+    - name: Build
+      working-directory: centroid-hmi/windows/runner/test
+      run: cmake --build build --config Debug
+
+    - name: Test
+      working-directory: centroid-hmi/windows/runner/test
+      run: ctest --test-dir build --build-config Debug --output-on-failure

--- a/centroid-hmi/windows/runner/CMakeLists.txt
+++ b/centroid-hmi/windows/runner/CMakeLists.txt
@@ -8,6 +8,7 @@ project(runner LANGUAGES CXX)
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
+  "gpu_watchdog.cpp"
   "main.cpp"
   "utils.cpp"
   "win32_window.cpp"
@@ -34,6 +35,9 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
 target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
+# WTSRegisterSessionNotification — the GPU watchdog uses RDP session changes as
+# a hint that the display adapter (and with it the D3D device) was swapped.
+target_link_libraries(${BINARY_NAME} PRIVATE "wtsapi32.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/centroid-hmi/windows/runner/flutter_window.cpp
+++ b/centroid-hmi/windows/runner/flutter_window.cpp
@@ -1,19 +1,71 @@
 #include "flutter_window.h"
 
+#include <windows.h>
+#include <wtsapi32.h>
+
+#include <cstdlib>
+#include <iostream>
 #include <optional>
+#include <string>
 
 #include "flutter/generated_plugin_registrant.h"
 
+// The GPU device-loss problem this file guards against is described in
+// gpu_watchdog.h. Everything below is adapter: window messages and engine
+// callbacks in, tfc::GpuWatchdog decisions out.
+//
+// Tunables, read once at startup:
+//   CENTROID_GPU_WATCHDOG=0               disable the watchdog entirely
+//   CENTROID_GPU_WATCHDOG_INTERVAL_MS=n   probe interval, default 5000
+
+namespace {
+
+// Timer id for the watchdog's WM_TIMER. Scoped to our window, so any value
+// that does not collide with another timer on the same HWND will do.
+constexpr UINT_PTR kWatchdogTimerId = 1;
+
+std::optional<std::string> GetEnvVar(const char* name) {
+  char* value = nullptr;
+  size_t len = 0;
+  if (_dupenv_s(&value, &len, name) != 0 || value == nullptr) {
+    return std::nullopt;
+  }
+  std::string result(value);
+  free(value);
+  return result;
+}
+
+const char* CStrOrNull(const std::optional<std::string>& value) {
+  return value.has_value() ? value->c_str() : nullptr;
+}
+
+tfc::GpuWatchdog::Config WatchdogConfigFromEnvironment() {
+  tfc::GpuWatchdog::Config config;
+  config.probe_interval_ms = tfc::ParseProbeIntervalMs(
+      CStrOrNull(GetEnvVar("CENTROID_GPU_WATCHDOG_INTERVAL_MS")),
+      config.probe_interval_ms);
+  return config;
+}
+
+bool WatchdogEnabledFromEnvironment() {
+  return tfc::ParseWatchdogEnabled(
+      CStrOrNull(GetEnvVar("CENTROID_GPU_WATCHDOG")), true);
+}
+
+void LogWatchdog(const std::string& message) {
+  std::cerr << "[gpu-watchdog] " << message << std::endl;
+}
+
+}  // namespace
+
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
-    : project_(project) {}
+    : project_(project),
+      watchdog_(WatchdogConfigFromEnvironment()),
+      watchdog_enabled_(WatchdogEnabledFromEnvironment()) {}
 
 FlutterWindow::~FlutterWindow() {}
 
-bool FlutterWindow::OnCreate() {
-  if (!Win32Window::OnCreate()) {
-    return false;
-  }
-
+bool FlutterWindow::CreateController() {
   RECT frame = GetClientArea();
 
   // The size here must match the window dimensions to avoid unnecessary surface
@@ -22,14 +74,17 @@ bool FlutterWindow::OnCreate() {
       frame.right - frame.left, frame.bottom - frame.top, project_);
   // Ensure that basic setup of the controller was successful.
   if (!flutter_controller_->engine() || !flutter_controller_->view()) {
+    flutter_controller_ = nullptr;
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
-  flutter_controller_->engine()->SetNextFrameCallback([&]() {
-    this->Show();
-  });
+  // The engine posts this back to the platform thread, so it is safe to touch
+  // watchdog state from it. It doubles as the stock runner template's "show the
+  // window once the first frame is ready" hook.
+  flutter_controller_->engine()->SetNextFrameCallback(
+      [this]() { this->OnFramePresented(); });
 
   // Flutter can complete the first frame before the "show window" callback is
   // registered. The following call ensures a frame is pending to ensure the
@@ -39,18 +94,126 @@ bool FlutterWindow::OnCreate() {
   return true;
 }
 
-void FlutterWindow::OnDestroy() {
-  if (flutter_controller_) {
-    flutter_controller_ = nullptr;
+void FlutterWindow::DestroyController() {
+  // Destroying the controller shuts the engine down, which takes egl::Manager
+  // with it: eglTerminate() releases the lost D3D device so the next
+  // eglInitialize() can create a healthy one.
+  flutter_controller_ = nullptr;
+}
+
+bool FlutterWindow::OnCreate() {
+  if (!Win32Window::OnCreate()) {
+    return false;
   }
 
+  if (!CreateController()) {
+    return false;
+  }
+
+  if (!watchdog_enabled_) {
+    LogWatchdog("disabled via CENTROID_GPU_WATCHDOG");
+    return true;
+  }
+
+  watchdog_hwnd_ = GetHandle();
+
+  // Device loss usually — but not always — comes with one of these messages.
+  // They only bring the next probe forward; the probe still decides whether
+  // anything actually broke.
+  if (::WTSRegisterSessionNotification(watchdog_hwnd_,
+                                       NOTIFY_FOR_THIS_SESSION)) {
+    session_notifications_registered_ = true;
+  } else {
+    // Not fatal: the periodic probe still catches the loss, just later.
+    LogWatchdog("WTSRegisterSessionNotification failed (error " +
+                std::to_string(::GetLastError()) +
+                "); relying on the periodic probe only");
+  }
+
+  ApplyAction(watchdog_.OnStarted());
+  return true;
+}
+
+void FlutterWindow::OnDestroy() {
+  if (watchdog_hwnd_ != nullptr) {
+    ::KillTimer(watchdog_hwnd_, kWatchdogTimerId);
+    if (session_notifications_registered_) {
+      ::WTSUnRegisterSessionNotification(watchdog_hwnd_);
+      session_notifications_registered_ = false;
+    }
+    // Also guards against OnDestroy running twice: Win32Window::Destroy calls
+    // it directly, and again via the WM_DESTROY it triggers.
+    watchdog_hwnd_ = nullptr;
+  }
+  DestroyController();
+
   Win32Window::OnDestroy();
+}
+
+void FlutterWindow::ApplyAction(const tfc::GpuWatchdog::Action& action) {
+  if (action.restart_engine) {
+    LogWatchdog("renderer is not presenting frames (EGL context lost?) — "
+                "restarting the Flutter engine, attempt " +
+                std::to_string(watchdog_.recovery_attempts()));
+    DestroyController();
+    // Deliberately does not touch first_frame_shown_. If the window was already
+    // shown it stays shown, and re-running Show() would undo an operator's
+    // maximise. If the GPU was dead before the very first frame, the flag is
+    // still false and the window has never appeared — then we do want the next
+    // successful frame to show it.
+    if (!CreateController()) {
+      LogWatchdog("engine restart FAILED — will retry");
+    }
+    // CreateController's own ForceRedraw is the next probe; the watchdog
+    // already accounted for that.
+  }
+
+  if (action.start_probe) {
+    StartProbe();
+  }
+
+  // A null handle means the window is going away — SetTimer would silently
+  // create an unowned timer that never routes a WM_TIMER back to us.
+  if (action.set_timer_ms != 0 && watchdog_hwnd_ != nullptr) {
+    ::SetTimer(watchdog_hwnd_, kWatchdogTimerId, action.set_timer_ms, nullptr);
+  }
+}
+
+void FlutterWindow::StartProbe() {
+  if (!flutter_controller_ || !flutter_controller_->engine()) {
+    return;
+  }
+  // Re-arm: the callback is one-shot and was consumed by the previous frame.
+  flutter_controller_->engine()->SetNextFrameCallback(
+      [this]() { this->OnFramePresented(); });
+  flutter_controller_->ForceRedraw();
+}
+
+void FlutterWindow::OnFramePresented() {
+  int attempts_before = watchdog_.recovery_attempts();
+  ApplyAction(watchdog_.OnFramePresented());
+  if (attempts_before > 0) {
+    LogWatchdog("renderer healthy again after " +
+                std::to_string(attempts_before) + " recovery attempt(s)");
+  }
+
+  if (!first_frame_shown_) {
+    first_frame_shown_ = true;
+    this->Show();
+  }
 }
 
 LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
+  // Handled before Flutter sees it — the timer is ours by id, and nothing in
+  // the engine should claim it.
+  if (message == WM_TIMER && wparam == kWatchdogTimerId) {
+    ApplyAction(watchdog_.OnTick());
+    return 0;
+  }
+
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =
@@ -63,7 +226,48 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
 
   switch (message) {
     case WM_FONTCHANGE:
-      flutter_controller_->engine()->ReloadSystemFonts();
+      // Null while the engine is being restarted; the fresh engine picks up
+      // the current fonts on its own.
+      if (flutter_controller_) {
+        flutter_controller_->engine()->ReloadSystemFonts();
+      }
+      break;
+
+    case WM_POWERBROADCAST:
+      // Resuming from sleep is the classic way a VM's virtual GPU comes back
+      // as a reset (or different) device.
+      if (wparam == PBT_APMRESUMEAUTOMATIC || wparam == PBT_APMRESUMESUSPEND) {
+        if (watchdog_enabled_ && flutter_controller_) {
+          LogWatchdog("probing after power resume");
+          ApplyAction(watchdog_.OnDeviceLossHint());
+        }
+      }
+      break;
+
+    case WM_DISPLAYCHANGE:
+      if (watchdog_enabled_ && flutter_controller_) {
+        LogWatchdog("probing after display change");
+        ApplyAction(watchdog_.OnDeviceLossHint());
+      }
+      break;
+
+    case WM_WTSSESSION_CHANGE:
+      // Connecting or disconnecting an RDP session swaps the session's display
+      // adapter, tearing down the D3D device ANGLE was rendering with.
+      switch (wparam) {
+        case WTS_CONSOLE_CONNECT:
+        case WTS_CONSOLE_DISCONNECT:
+        case WTS_REMOTE_CONNECT:
+        case WTS_REMOTE_DISCONNECT:
+        case WTS_SESSION_UNLOCK:
+          if (watchdog_enabled_ && flutter_controller_) {
+            LogWatchdog("probing after session change");
+            ApplyAction(watchdog_.OnDeviceLossHint());
+          }
+          break;
+        default:
+          break;
+      }
       break;
   }
 

--- a/centroid-hmi/windows/runner/flutter_window.h
+++ b/centroid-hmi/windows/runner/flutter_window.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "gpu_watchdog.h"
 #include "win32_window.h"
 
 // A window that does nothing but host a Flutter view.
@@ -23,11 +24,49 @@ class FlutterWindow : public Win32Window {
                          LPARAM const lparam) noexcept override;
 
  private:
+  // --- Flutter engine lifecycle -------------------------------------------
+  //
+  // Split out of OnCreate so the GPU watchdog can rebuild the engine without
+  // tearing down the top-level window.
+
+  // Builds a FlutterViewController and attaches its view as this window's
+  // child content. Returns false if the engine failed to start.
+  bool CreateController();
+
+  // Tears the FlutterViewController down. This runs egl::Manager's destructor
+  // inside the engine, which calls eglTerminate() and releases the D3D device.
+  void DestroyController();
+
+  // --- GPU watchdog adapter -----------------------------------------------
+  //
+  // All the decisions live in tfc::GpuWatchdog (unit tested); this class only
+  // translates window messages and engine callbacks into watchdog events, and
+  // carries out whatever the watchdog asks for.
+
+  void ApplyAction(const tfc::GpuWatchdog::Action& action);
+
+  // Asks the engine for a frame and re-arms the next-frame callback.
+  void StartProbe();
+
+  // Invoked on the platform thread when the engine presents a frame.
+  void OnFramePresented();
+
   // The project to run.
   flutter::DartProject project_;
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // Watchdog state. Touched only on the platform thread.
+  tfc::GpuWatchdog watchdog_;
+  bool watchdog_enabled_ = true;
+  bool first_frame_shown_ = false;
+  bool session_notifications_registered_ = false;
+
+  // Cached copy of the window handle for watchdog teardown. Win32Window clears
+  // window_handle_ *before* dispatching WM_DESTROY to OnDestroy, so GetHandle()
+  // is already null by the time we need to KillTimer and unregister.
+  HWND watchdog_hwnd_ = nullptr;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/centroid-hmi/windows/runner/gpu_watchdog.cpp
+++ b/centroid-hmi/windows/runner/gpu_watchdog.cpp
@@ -1,0 +1,137 @@
+#include "gpu_watchdog.h"
+
+#include <cstdlib>
+
+namespace tfc {
+namespace {
+
+// Below a second the probe stops measuring anything useful and just competes
+// with real frames.
+constexpr unsigned int kMinProbeIntervalMs = 1000;
+
+bool EqualsIgnoreCase(const char* a, const char* b) {
+  for (; *a != '\0' && *b != '\0'; a++, b++) {
+    char lhs = (*a >= 'A' && *a <= 'Z') ? static_cast<char>(*a + 32) : *a;
+    char rhs = (*b >= 'A' && *b <= 'Z') ? static_cast<char>(*b + 32) : *b;
+    if (lhs != rhs) {
+      return false;
+    }
+  }
+  return *a == *b;
+}
+
+}  // namespace
+
+GpuWatchdog::GpuWatchdog() : GpuWatchdog(Config()) {}
+
+GpuWatchdog::GpuWatchdog(Config config) : config_(config) {}
+
+GpuWatchdog::Action GpuWatchdog::OnStarted() {
+  Action action;
+  probe_outstanding_ = true;
+  action.start_probe = true;
+  action.set_timer_ms = config_.probe_interval_ms;
+  return action;
+}
+
+GpuWatchdog::Action GpuWatchdog::OnTick() {
+  Action action;
+
+  if (probe_outstanding_) {
+    missed_probes_++;
+    if (missed_probes_ >= config_.missed_probes_before_recovery) {
+      recovery_attempts_++;
+      missed_probes_ = 0;
+      // Recreating the controller issues its own ForceRedraw and arms the
+      // next-frame callback, so the restart *is* the next probe. Leaving the
+      // flag set means the following ticks judge the new engine.
+      probe_outstanding_ = true;
+      action.restart_engine = true;
+      action.set_timer_ms = BackoffMs();
+      return action;
+    }
+  }
+
+  // Either nothing was outstanding, or we are still under the failure
+  // threshold — keep asking, the renderer may come back on its own.
+  probe_outstanding_ = true;
+  action.start_probe = true;
+  return action;
+}
+
+GpuWatchdog::Action GpuWatchdog::OnFramePresented() {
+  Action action;
+  probe_outstanding_ = false;
+  missed_probes_ = 0;
+
+  if (recovery_attempts_ > 0) {
+    // The engine we restarted is drawing again: drop the backoff.
+    recovery_attempts_ = 0;
+    action.set_timer_ms = config_.probe_interval_ms;
+  }
+  // Otherwise leave the timer alone. Re-arming it on every presented frame
+  // would push the next tick out indefinitely on an animating page, and the
+  // watchdog would never probe.
+
+  return action;
+}
+
+GpuWatchdog::Action GpuWatchdog::OnDeviceLossHint() {
+  Action action;
+  // Deliberately does not touch missed_probes_: a flood of session-change
+  // messages must not be able to hold the failure count at zero while frames
+  // are actually missing.
+  probe_outstanding_ = true;
+  action.start_probe = true;
+  action.set_timer_ms = config_.probe_interval_ms;
+  return action;
+}
+
+unsigned int GpuWatchdog::BackoffMs() const {
+  unsigned int backoff = config_.probe_interval_ms;
+  for (int i = 1; i < recovery_attempts_; i++) {
+    if (backoff >= config_.max_probe_interval_ms) {
+      break;
+    }
+    backoff *= 2;
+  }
+  return backoff > config_.max_probe_interval_ms ? config_.max_probe_interval_ms
+                                                 : backoff;
+}
+
+bool ParseWatchdogEnabled(const char* raw, bool fallback) {
+  if (raw == nullptr || *raw == '\0') {
+    return fallback;
+  }
+  const char* falsy[] = {"0", "false", "no", "off"};
+  for (const char* candidate : falsy) {
+    if (EqualsIgnoreCase(raw, candidate)) {
+      return false;
+    }
+  }
+  const char* truthy[] = {"1", "true", "yes", "on"};
+  for (const char* candidate : truthy) {
+    if (EqualsIgnoreCase(raw, candidate)) {
+      return true;
+    }
+  }
+  return fallback;
+}
+
+unsigned int ParseProbeIntervalMs(const char* raw, unsigned int fallback) {
+  if (raw == nullptr || *raw == '\0') {
+    return fallback;
+  }
+  char* end = nullptr;
+  long parsed = std::strtol(raw, &end, 10);
+  // Reject trailing garbage ("5000ms") as well as outright nonsense.
+  if (end == raw || *end != '\0') {
+    return fallback;
+  }
+  if (parsed < static_cast<long>(kMinProbeIntervalMs)) {
+    return fallback;
+  }
+  return static_cast<unsigned int>(parsed);
+}
+
+}  // namespace tfc

--- a/centroid-hmi/windows/runner/gpu_watchdog.h
+++ b/centroid-hmi/windows/runner/gpu_watchdog.h
@@ -1,0 +1,111 @@
+#ifndef RUNNER_GPU_WATCHDOG_H_
+#define RUNNER_GPU_WATCHDOG_H_
+
+// GPU device-loss watchdog.
+//
+// The problem, as it appears in the logs:
+//
+//   [ERROR:...egl/egl.cc(57)] EGL Error: Context Lost (12302) in .../context.cc
+//   [ERROR:...gpu_surface_gl_skia.cc(220)] Could not make the context current
+//                                          to acquire the frame.
+//
+// repeating forever, with the process alive but the window frozen on its last
+// frame. It means the D3D11 device ANGLE renders through was destroyed under
+// it. In a VM that happens when the host sleeps and the virtual GPU resets,
+// when an RDP session connects or disconnects and Windows swaps the session's
+// display adapter, or when the graphics driver resets (TDR).
+//
+// Recovering requires rebuilding the EGL display, context and surface plus
+// Skia's GrDirectContext. The Flutter Windows embedder does not do that — it
+// retries eglMakeCurrent every frame and fails every frame. Those sources ship
+// as a prebuilt flutter_windows.dll, so we cannot fix it there without forking
+// the engine. What the runner *can* do is destroy and recreate
+// FlutterViewController: that runs egl::Manager's destructor (eglTerminate,
+// releasing the dead device) and then its constructor (eglInitialize, creating
+// a fresh one). The Dart VM restarts with it, so the app reboots — which for a
+// 24/7 HMI beats a permanently frozen screen.
+//
+// This class owns only the decision: is the renderer dead, and what should the
+// host do about it. It is deliberately free of Win32 and Flutter types so the
+// decision can be unit tested without a GPU — see test/gpu_watchdog_test.cpp.
+// FlutterWindow is the adapter that feeds it events and executes its actions.
+//
+// Detection works by probing: ask the engine for a frame (ForceRedraw) and arm
+// the next-frame callback, which only fires once a frame has actually been
+// presented. Consecutive unanswered probes mean the renderer is gone.
+
+namespace tfc {
+
+class GpuWatchdog {
+ public:
+  struct Config {
+    // How often to probe, and how long an unanswered probe is given.
+    unsigned int probe_interval_ms = 5000;
+
+    // Consecutive unanswered probes before the renderer is judged dead. At the
+    // default interval that is ~10s of no presented frame: long enough not to
+    // trip on one slow frame, short enough that an operator is not left
+    // staring at a stale screen.
+    int missed_probes_before_recovery = 2;
+
+    // Ceiling for the post-recovery backoff, so a GPU that never comes back is
+    // retried slowly instead of rebooting the engine every few seconds.
+    unsigned int max_probe_interval_ms = 60000;
+  };
+
+  // What the host should do in response to an event.
+  struct Action {
+    // Call ForceRedraw and re-arm the next-frame callback.
+    bool start_probe = false;
+
+    // Destroy and recreate the FlutterViewController.
+    bool restart_engine = false;
+
+    // Re-arm the tick timer with this period. 0 means "leave it alone".
+    unsigned int set_timer_ms = 0;
+  };
+
+  // Two overloads rather than a defaulted argument: `Config()` cannot be named
+  // as a default argument inside the class that encloses Config.
+  GpuWatchdog();
+  explicit GpuWatchdog(Config config);
+
+  // The engine is up; begin watching.
+  Action OnStarted();
+
+  // The tick timer fired: judge the outstanding probe, then start a new one.
+  Action OnTick();
+
+  // The engine presented a frame — the only positive proof of a live renderer.
+  Action OnFramePresented();
+
+  // A window message arrived that commonly accompanies device loss (power
+  // resume, display change, session change). This only brings the next probe
+  // forward; the probe still decides whether anything actually broke, so a
+  // benign resolution change cannot reboot the engine on its own.
+  Action OnDeviceLossHint();
+
+  int missed_probes() const { return missed_probes_; }
+  int recovery_attempts() const { return recovery_attempts_; }
+  bool probe_outstanding() const { return probe_outstanding_; }
+
+ private:
+  // Period to wait before judging the engine we just restarted.
+  unsigned int BackoffMs() const;
+
+  Config config_;
+  bool probe_outstanding_ = false;
+  int missed_probes_ = 0;
+  int recovery_attempts_ = 0;
+};
+
+// Parses CENTROID_GPU_WATCHDOG. Returns |fallback| when unset or unrecognised.
+bool ParseWatchdogEnabled(const char* raw, bool fallback);
+
+// Parses CENTROID_GPU_WATCHDOG_INTERVAL_MS. Returns |fallback| when unset,
+// malformed, or below the one-second floor.
+unsigned int ParseProbeIntervalMs(const char* raw, unsigned int fallback);
+
+}  // namespace tfc
+
+#endif  // RUNNER_GPU_WATCHDOG_H_

--- a/centroid-hmi/windows/runner/test/CMakeLists.txt
+++ b/centroid-hmi/windows/runner/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(runner_tests LANGUAGES CXX)
+
+# Standalone project, deliberately NOT included by ../CMakeLists.txt: the
+# Flutter Windows build should not have to build tests, and these tests should
+# not need Windows. Everything under test here is platform-free, so this
+# configures and runs on Linux and macOS too.
+#
+#   cmake -S . -B build && cmake --build build && ctest --test-dir build
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+add_executable(gpu_watchdog_test
+  "gpu_watchdog_test.cpp"
+  "../gpu_watchdog.cpp"
+)
+target_include_directories(gpu_watchdog_test PRIVATE "..")
+
+if(MSVC)
+  target_compile_options(gpu_watchdog_test PRIVATE /W4)
+else()
+  target_compile_options(gpu_watchdog_test PRIVATE -Wall -Wextra)
+endif()
+
+add_test(NAME gpu_watchdog COMMAND gpu_watchdog_test)

--- a/centroid-hmi/windows/runner/test/gpu_watchdog_test.cpp
+++ b/centroid-hmi/windows/runner/test/gpu_watchdog_test.cpp
@@ -1,0 +1,243 @@
+// Tests for the GPU device-loss watchdog state machine.
+//
+// The watchdog decides *whether* the renderer is dead and *what* to do about
+// it. It deliberately knows nothing about Win32 or Flutter so that the whole
+// decision can be exercised here, on any platform, without a GPU — the failure
+// it guards against (a VM resuming from host sleep, an RDP session swapping the
+// display adapter) is not something a test can stage for real.
+
+#include "../gpu_watchdog.h"
+
+#include "test_harness.h"
+
+namespace {
+
+using tfc::GpuWatchdog;
+
+GpuWatchdog::Config TestConfig() {
+  GpuWatchdog::Config config;
+  config.probe_interval_ms = 5000;
+  config.missed_probes_before_recovery = 2;
+  config.max_probe_interval_ms = 60000;
+  return config;
+}
+
+}  // namespace
+
+// --- Steady state -----------------------------------------------------------
+
+TEST(started_arms_the_timer_and_probes_immediately) {
+  GpuWatchdog watchdog(TestConfig());
+
+  GpuWatchdog::Action action = watchdog.OnStarted();
+
+  CHECK(action.start_probe);
+  CHECK(!action.restart_engine);
+  CHECK_EQ(action.set_timer_ms, 5000u);
+}
+
+TEST(tick_starts_a_probe_when_none_is_outstanding) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnFramePresented();
+
+  GpuWatchdog::Action action = watchdog.OnTick();
+
+  CHECK(action.start_probe);
+  CHECK(!action.restart_engine);
+}
+
+TEST(a_presented_frame_clears_the_outstanding_probe) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  CHECK(watchdog.probe_outstanding());
+
+  watchdog.OnFramePresented();
+
+  // A presented frame is the only positive proof that the renderer is alive.
+  // If it does not clear the flag, every subsequent tick counts a phantom
+  // miss and a perfectly healthy app drifts towards a restart.
+  CHECK(!watchdog.probe_outstanding());
+}
+
+TEST(an_answered_probe_never_counts_as_missed) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnFramePresented();
+
+  for (int i = 0; i < 100; i++) {
+    GpuWatchdog::Action action = watchdog.OnTick();
+    CHECK(!action.restart_engine);
+    // Checked every iteration, not just at the end: a miss that is counted on
+    // the tick and cleared by the following frame would be invisible from
+    // outside the loop, but it is exactly the bookkeeping bug that would make
+    // the watchdog restart a healthy engine under a slower frame cadence.
+    CHECK_EQ(watchdog.missed_probes(), 0);
+    watchdog.OnFramePresented();
+  }
+
+  CHECK_EQ(watchdog.missed_probes(), 0);
+  CHECK_EQ(watchdog.recovery_attempts(), 0);
+}
+
+// --- Detecting a dead renderer ---------------------------------------------
+
+TEST(one_unanswered_probe_is_not_enough_to_restart) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();  // probe outstanding, no frame answers it
+
+  GpuWatchdog::Action action = watchdog.OnTick();
+
+  CHECK_EQ(watchdog.missed_probes(), 1);
+  CHECK(!action.restart_engine);
+  // Keep asking — the renderer may still come back on its own.
+  CHECK(action.start_probe);
+}
+
+TEST(restarts_the_engine_after_the_configured_number_of_missed_probes) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+
+  CHECK(!watchdog.OnTick().restart_engine);      // missed 1
+  GpuWatchdog::Action action = watchdog.OnTick();  // missed 2 -> recover
+
+  CHECK(action.restart_engine);
+  CHECK_EQ(watchdog.recovery_attempts(), 1);
+}
+
+TEST(a_frame_arriving_late_cancels_the_pending_recovery) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+
+  watchdog.OnTick();          // missed 1
+  watchdog.OnFramePresented();  // renderer recovered on its own
+
+  CHECK_EQ(watchdog.missed_probes(), 0);
+  CHECK(!watchdog.OnTick().restart_engine);
+  CHECK_EQ(watchdog.recovery_attempts(), 0);
+}
+
+TEST(restart_treats_the_new_engine_as_probed_and_re_arms_the_count) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnTick();
+  CHECK(watchdog.OnTick().restart_engine);
+
+  // Recreating the controller issues its own ForceRedraw, so the restart
+  // itself counts as the next probe rather than needing a separate one.
+  CHECK(watchdog.probe_outstanding());
+  CHECK_EQ(watchdog.missed_probes(), 0);
+
+  // A second restart must take another full round of missed probes.
+  CHECK(!watchdog.OnTick().restart_engine);
+  CHECK(watchdog.OnTick().restart_engine);
+  CHECK_EQ(watchdog.recovery_attempts(), 2);
+}
+
+// --- Backoff ----------------------------------------------------------------
+
+TEST(recovery_backs_off_geometrically_and_caps) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+
+  const unsigned int expected[] = {5000, 10000, 20000, 40000, 60000, 60000};
+  for (unsigned int want : expected) {
+    GpuWatchdog::Action action;
+    do {
+      action = watchdog.OnTick();
+    } while (!action.restart_engine);
+    CHECK_EQ(action.set_timer_ms, want);
+  }
+}
+
+TEST(a_healthy_frame_after_recovery_restores_the_base_interval) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnTick();
+  CHECK(watchdog.OnTick().restart_engine);
+  CHECK_EQ(watchdog.recovery_attempts(), 1);
+
+  GpuWatchdog::Action action = watchdog.OnFramePresented();
+
+  CHECK_EQ(watchdog.recovery_attempts(), 0);
+  CHECK_EQ(action.set_timer_ms, 5000u);
+}
+
+TEST(a_healthy_frame_in_steady_state_does_not_touch_the_timer) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+
+  GpuWatchdog::Action action = watchdog.OnFramePresented();
+
+  // 0 means "leave the timer alone" — re-arming it on every presented frame
+  // would push the next tick out indefinitely on an animating page and the
+  // watchdog would never probe.
+  CHECK_EQ(action.set_timer_ms, 0u);
+}
+
+// --- Device-loss hints from window messages --------------------------------
+
+TEST(a_hint_probes_immediately_and_restarts_the_interval) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnFramePresented();
+
+  GpuWatchdog::Action action = watchdog.OnDeviceLossHint();
+
+  CHECK(action.start_probe);
+  CHECK(!action.restart_engine);
+  CHECK_EQ(action.set_timer_ms, 5000u);
+}
+
+TEST(a_hint_alone_never_restarts_the_engine) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnFramePresented();
+
+  // WM_DISPLAYCHANGE fires for benign things like a resolution change. The
+  // probe, not the message, decides whether anything actually broke.
+  for (int i = 0; i < 50; i++) {
+    CHECK(!watchdog.OnDeviceLossHint().restart_engine);
+    watchdog.OnFramePresented();
+  }
+  CHECK_EQ(watchdog.recovery_attempts(), 0);
+}
+
+TEST(a_hint_does_not_reset_an_in_progress_failure_count) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnTick();  // missed 1
+
+  watchdog.OnDeviceLossHint();
+
+  // A hint arriving while frames are already missing must not let a flood of
+  // session-change messages hold the failure count at zero forever.
+  CHECK_EQ(watchdog.missed_probes(), 1);
+  CHECK(watchdog.OnTick().restart_engine);
+}
+
+// --- Config parsing ---------------------------------------------------------
+
+TEST(watchdog_is_enabled_unless_explicitly_switched_off) {
+  CHECK(tfc::ParseWatchdogEnabled(nullptr, true));
+  CHECK(tfc::ParseWatchdogEnabled("1", true));
+  CHECK(tfc::ParseWatchdogEnabled("yes", true));
+  CHECK(!tfc::ParseWatchdogEnabled("0", true));
+  CHECK(!tfc::ParseWatchdogEnabled("false", true));
+}
+
+TEST(probe_interval_falls_back_when_absent_or_nonsensical) {
+  CHECK_EQ(tfc::ParseProbeIntervalMs(nullptr, 5000), 5000u);
+  CHECK_EQ(tfc::ParseProbeIntervalMs("", 5000), 5000u);
+  CHECK_EQ(tfc::ParseProbeIntervalMs("banana", 5000), 5000u);
+  CHECK_EQ(tfc::ParseProbeIntervalMs("-1", 5000), 5000u);
+  // Below a second the probe just competes with real frames for no benefit.
+  CHECK_EQ(tfc::ParseProbeIntervalMs("250", 5000), 5000u);
+  CHECK_EQ(tfc::ParseProbeIntervalMs("1000", 5000), 1000u);
+  CHECK_EQ(tfc::ParseProbeIntervalMs("30000", 5000), 30000u);
+}
+
+int main() {
+  std::printf("gpu_watchdog_test\n");
+  return tfc_test::RunAll();
+}

--- a/centroid-hmi/windows/runner/test/test_harness.h
+++ b/centroid-hmi/windows/runner/test/test_harness.h
@@ -1,0 +1,93 @@
+#ifndef RUNNER_TEST_TEST_HARNESS_H_
+#define RUNNER_TEST_TEST_HARNESS_H_
+
+// A ~60 line, dependency-free test harness.
+//
+// The runner has no other C++ tests and no package manager, so pulling in
+// GoogleTest for a handful of state-machine assertions would cost more than it
+// buys. If this file ever needs fixtures, parameterisation or death tests,
+// that is the signal to switch to GoogleTest via FetchContent.
+//
+// Usage:
+//   TEST(does_the_thing) {
+//     CHECK(condition);
+//     CHECK_EQ(actual, expected);
+//   }
+//   int main() { return tfc_test::RunAll(); }
+
+#include <cstdio>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace tfc_test {
+
+struct TestCase {
+  const char* name;
+  std::function<void()> body;
+};
+
+inline std::vector<TestCase>& Registry() {
+  static std::vector<TestCase> registry;
+  return registry;
+}
+
+inline int& FailureCount() {
+  static int failures = 0;
+  return failures;
+}
+
+inline void ReportFailure(const char* file, int line, const std::string& what) {
+  FailureCount()++;
+  std::printf("    FAIL %s:%d\n         %s\n", file, line, what.c_str());
+}
+
+struct Registrar {
+  Registrar(const char* name, std::function<void()> body) {
+    Registry().push_back({name, std::move(body)});
+  }
+};
+
+inline int RunAll() {
+  int failed_tests = 0;
+  for (const auto& test : Registry()) {
+    int before = FailureCount();
+    std::printf("  %s\n", test.name);
+    test.body();
+    if (FailureCount() != before) {
+      failed_tests++;
+    }
+  }
+  std::printf("\n%zu tests, %d failed, %d assertion failure(s)\n",
+              Registry().size(), failed_tests, FailureCount());
+  return FailureCount() == 0 ? 0 : 1;
+}
+
+}  // namespace tfc_test
+
+#define TEST(name)                                                     \
+  static void name();                                                  \
+  static tfc_test::Registrar registrar_##name(#name, name);            \
+  static void name()
+
+#define CHECK(cond)                                                    \
+  do {                                                                 \
+    if (!(cond)) {                                                     \
+      tfc_test::ReportFailure(__FILE__, __LINE__, "CHECK(" #cond ")"); \
+    }                                                                  \
+  } while (0)
+
+#define CHECK_EQ(actual, expected)                                     \
+  do {                                                                 \
+    auto actual_value = (actual);                                      \
+    auto expected_value = (expected);                                  \
+    if (!(actual_value == expected_value)) {                           \
+      std::ostringstream oss;                                          \
+      oss << "CHECK_EQ(" #actual ", " #expected ") -- got "            \
+          << actual_value << ", want " << expected_value;              \
+      tfc_test::ReportFailure(__FILE__, __LINE__, oss.str());          \
+    }                                                                  \
+  } while (0)
+
+#endif  // RUNNER_TEST_TEST_HARNESS_H_


### PR DESCRIPTION
## The bug

After a host sleep/resume cycle on a Windows VM, the HMI was frozen and unresponsive, logging this pair on every frame, forever:

```
[ERROR:flutter/shell/platform/windows/egl/egl.cc(57)] EGL Error: Context Lost (12302) in .../egl/context.cc:33
[ERROR:flutter/shell/gpu/gpu_surface_gl_skia.cc(220)] Could not make the context current to acquire the frame.
```

The D3D11 device backing ANGLE was destroyed underneath the engine. The process stayed alive the whole time — the OPC UA isolate kept logging, the message loop kept pumping, clicks were almost certainly still being handled — it just never presented another pixel. "Frozen" here means the last frame stuck on screen, not a deadlock.

In a VM this happens when the host sleeps and the virtual GPU resets, when an RDP session connects/disconnects and Windows swaps the session's display adapter, or on a driver TDR.

The `SecureChannel must be connected to send request` errors in the same log are a sibling symptom of the same suspend (dead TCP sockets, `ua_client.c:814`), not a cause. The retry loop handled them.

## Why the fix is in the runner and not the engine

Recovering requires rebuilding the EGL display, context and surface plus Skia's `GrDirectContext`. The Flutter Windows embedder doesn't — it retries `eglMakeCurrent` every frame and fails every frame. Those sources ship prebuilt in `flutter_windows.dll`, so fixing them means forking the engine and pinning every build to `--local-engine`. Worth raising upstream; not worth owning.

The runner can reach the same end state from outside: destroying and recreating `FlutterViewController` runs `egl::Manager`'s destructor (`eglTerminate`, releasing the dead device) and then its constructor (`eglInitialize`, creating a fresh one). The Dart VM restarts with it, so the app reboots — which for a 24/7 HMI beats a permanently frozen screen.

## How detection works

Every 5s: call `ForceRedraw()` and arm the engine's next-frame callback, which only fires once a frame has actually been *presented*. Two consecutive unanswered probes (~10s) means the renderer is dead. Recovery backs off geometrically to a 60s ceiling and resets on the first healthy frame.

`WM_POWERBROADCAST`, `WM_DISPLAYCHANGE` and `WM_WTSSESSION_CHANGE` only bring the next probe *forward*. They never restart on their own, so a benign resolution change can't reboot the HMI.

A blocked platform thread can't false-positive either: the timer lives on that thread, so if it's blocked no tick fires at all.

## Structure

The decision logic is in `tfc::GpuWatchdog` — no Win32, no Flutter types — so it can be unit tested without a GPU. `FlutterWindow` is a thin adapter: events in, actions out.

16 tests in `centroid-hmi/windows/runner/test/`, wired into `test.yml` as `windows-runner-cpp-test` (ubuntu + windows). They were written before the implementation, then mutation-tested — **one mutant survived the first pass**: deleting `probe_outstanding_ = false;` from `OnFramePresented`, the single most important line in the class, passed all 15 tests. Two tests were masking it via a later counter reset. Added a direct assertion and moved the loop check inside the iteration; 5/5 mutants now caught.

## Two bugs found while wiring the adapter

- `Win32Window` clears `window_handle_` **before** dispatching `WM_DESTROY` to `OnDestroy` (`win32_window.cpp:183-184`), so `KillTimer`/`WTSUnRegisterSessionNotification` against `GetHandle()` would have silently no-oped. Now uses a cached handle, which is also idempotent across the double-`OnDestroy` path.
- Marking the first frame as shown during recovery would have left the window hidden forever if the GPU was already dead before the first frame. It also would have undone an operator's maximise on every recovery.

## Review focus / what is not yet proven

CI compiles this (`flutter build windows --release` runs on PRs), which is the main thing I couldn't do locally — the Windows-only file was type-checked against hand-written API stubs, not a real build.

Green CI still does **not** prove the watchdog works. Two assumptions need a real device-loss event on hardware:

1. That `SetNextFrameCallback` withholds when `AcquireFrame` fails. If it fires anyway, detection silently never triggers — a safe failure, just useless.
2. That `eglTerminate` on an already-lost device tears down cleanly.

Failure modes are asymmetric: a false negative is today's behaviour, a false positive reboots the UI spuriously. Blast radius is Windows MSIX only — the eLinux/docker production HMI doesn't build this code.

Enabled by default. `CENTROID_GPU_WATCHDOG=0` disables; `CENTROID_GPU_WATCHDOG_INTERVAL_MS` tunes the interval.

## Testing

To reproduce on a VM: `flutter run -d windows`, then sleep the host or bounce the RDP session, and watch for `[gpu-watchdog]` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
