### PR TITLE
feat(page-editor): rotate a multi-selection as a group

### DIFF
--- a/lib/pages/page_editor.dart
+++ b/lib/pages/page_editor.dart
@@ -93,6 +93,183 @@ bool isAlreadyAtBack<T>(List<T> assets, Set<T> targets) {
   return true;
 }
 
+/// One asset's placement on the canvas, in the normalized 0..1 units the
+/// editor stores. Exists so [rotateGroup] can be exercised — and reasoned
+/// about — without building real assets.
+@visibleForTesting
+@immutable
+class AssetPlacement {
+  const AssetPlacement({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+    this.angle,
+  });
+
+  /// Centre point, as a fraction of the canvas (matches `Coordinates`).
+  final double x;
+  final double y;
+
+  /// Extents, as a fraction of the canvas (matches `RelativeSize`).
+  final double width;
+  final double height;
+
+  /// Rotation in degrees, clockwise on screen. Null means "never rotated";
+  /// [rotateGroup] preserves that distinction because `AssetStack` only
+  /// applies the page's mirror transform to assets with a non-null angle.
+  final double? angle;
+
+  @override
+  String toString() =>
+      'AssetPlacement(x: $x, y: $y, width: $width, height: $height, '
+      'angle: $angle)';
+}
+
+/// Normalizes an angle in degrees to [0, 360).
+double _normalizeAngle(double degrees) {
+  final wrapped = degrees % 360;
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+}
+
+/// cos/sin packed as (dx, dy), exact for quarter turns.
+///
+/// `math.cos(pi / 2)` is 6.1e-17, not 0, so a nominally rigid 90° turn would
+/// leak a little of each axis into the other — a systematic error that repeats
+/// in the same direction every rotation. The quarter turns are the only
+/// rotations the editor's menu offers, so they are table lookups rather than
+/// trig. Rounding in the surrounding arithmetic still costs an ulp or so per
+/// turn; this only removes the part that would accumulate.
+Offset _rotationFactors(double degrees) {
+  final normalized = _normalizeAngle(degrees);
+  if (normalized == 0) return const Offset(1, 0);
+  if (normalized == 90) return const Offset(0, 1);
+  if (normalized == 180) return const Offset(-1, 0);
+  if (normalized == 270) return const Offset(0, -1);
+  final radians = normalized * math.pi / 180;
+  return Offset(math.cos(radians), math.sin(radians));
+}
+
+/// Rotates [placements] as one rigid group about the centre of their combined
+/// bounding box: every asset both spins on its own centre and orbits the
+/// group's, the way a selection rotates in a drawing tool.
+///
+/// [degrees] is clockwise on screen, matching `Coordinates.angle` and
+/// `Transform.rotate`.
+///
+/// [aspectRatio] is the canvas's width / height. It is required because x and
+/// y are normalized independently against a canvas that is not square — a
+/// rotation applied directly to normalized coordinates would shear the group.
+/// The maths therefore runs in units of canvas height (x scaled by
+/// [aspectRatio]) and converts back at the end.
+///
+/// The bounding box is built from each asset's *rotated* extents, so a quarter
+/// turn maps the box onto itself and the group's centre stays put. Combined
+/// with the exact quarter-turn factors above, that makes CW-then-CCW a round
+/// trip to within a rounding ulp, with no direction the error can accumulate
+/// in.
+///
+/// A group that would leave the canvas is translated back in as a unit rather
+/// than clamped per asset, which would collapse the layout. A group too large
+/// to fit is aligned to the top/left edge and may overhang; as a last resort
+/// centres are clamped into 0..1 so no asset ends up unreachable off-canvas.
+///
+/// Returns a new list positionally matching [placements]; nothing is mutated.
+@visibleForTesting
+List<AssetPlacement> rotateGroup({
+  required List<AssetPlacement> placements,
+  required double degrees,
+  required double aspectRatio,
+}) {
+  if (placements.isEmpty) return const [];
+  // A degenerate canvas has no meaningful aspect; fall back to square rather
+  // than producing NaN coordinates.
+  final aspect = (aspectRatio.isFinite && aspectRatio > 0) ? aspectRatio : 1.0;
+
+  // Half-extents of an asset's axis-aligned bounding box once its own
+  // rotation is applied — the same formula AssetStack uses to size the
+  // Positioned that holds a rotated visual. Uses the exact quarter-turn
+  // factors for the same reason the orbit below does: the box decides where
+  // the group centre sits, so trig noise here would drift the whole selection.
+  Offset halfExtents(double width, double height, double? angle) {
+    final factors = _rotationFactors(angle ?? 0.0);
+    final cosA = factors.dx.abs();
+    final sinA = factors.dy.abs();
+    final halfW = width * aspect / 2;
+    final halfH = height / 2;
+    return Offset(halfW * cosA + halfH * sinA, halfW * sinA + halfH * cosA);
+  }
+
+  // 1) Bounding box of the selection, in canvas-height units.
+  var minX = double.infinity;
+  var minY = double.infinity;
+  var maxX = double.negativeInfinity;
+  var maxY = double.negativeInfinity;
+  for (final p in placements) {
+    final half = halfExtents(p.width, p.height, p.angle);
+    minX = math.min(minX, p.x * aspect - half.dx);
+    maxX = math.max(maxX, p.x * aspect + half.dx);
+    minY = math.min(minY, p.y - half.dy);
+    maxY = math.max(maxY, p.y + half.dy);
+  }
+  final centreX = (minX + maxX) / 2;
+  final centreY = (minY + maxY) / 2;
+
+  // 2) Orbit each centre about the group centre and spin the asset itself.
+  final factors = _rotationFactors(degrees);
+  final rotated = <AssetPlacement>[];
+  for (final p in placements) {
+    final dx = p.x * aspect - centreX;
+    final dy = p.y - centreY;
+    final newAngle = _normalizeAngle((p.angle ?? 0.0) + degrees);
+    rotated.add(AssetPlacement(
+      x: (centreX + dx * factors.dx - dy * factors.dy) / aspect,
+      y: centreY + dx * factors.dy + dy * factors.dx,
+      width: p.width,
+      height: p.height,
+      // Back at zero means back to null. AssetStack skips the page's mirror
+      // transform for a null angle, so rotating a selection and rotating it
+      // back has to restore the null or the visual would start flipping on
+      // mirrored pages — a no-op round trip must really be a no-op. The cost
+      // is that an angle stored explicitly as 0 collapses to null.
+      angle: newAngle == 0 ? null : newAngle,
+    ));
+  }
+
+  // 3) Translate the group back onto the canvas if the rotation pushed it off.
+  var shiftX = 0.0;
+  var shiftY = 0.0;
+  var rMinX = double.infinity;
+  var rMinY = double.infinity;
+  var rMaxX = double.negativeInfinity;
+  var rMaxY = double.negativeInfinity;
+  for (final p in rotated) {
+    final half = halfExtents(p.width, p.height, p.angle);
+    rMinX = math.min(rMinX, p.x * aspect - half.dx);
+    rMaxX = math.max(rMaxX, p.x * aspect + half.dx);
+    rMinY = math.min(rMinY, p.y - half.dy);
+    rMaxY = math.max(rMaxY, p.y + half.dy);
+  }
+  // Pull the leading edge in first, so an oversized group overhangs the
+  // bottom/right rather than the top/left where it is harder to grab.
+  if (rMaxX > aspect) shiftX = aspect - rMaxX;
+  if (rMinX + shiftX < 0) shiftX = -rMinX;
+  if (rMaxY > 1) shiftY = 1 - rMaxY;
+  if (rMinY + shiftY < 0) shiftY = -rMinY;
+
+  if (shiftX == 0 && shiftY == 0) return rotated;
+  return [
+    for (final p in rotated)
+      AssetPlacement(
+        x: (p.x + shiftX / aspect).clamp(0.0, 1.0),
+        y: (p.y + shiftY).clamp(0.0, 1.0),
+        width: p.width,
+        height: p.height,
+        angle: p.angle,
+      ),
+  ];
+}
+
 /// Projects a drag delta from the rotated GestureDetector's local frame
 /// back into the canvas (parent) frame. The editor's per-asset
 /// GestureDetector lives inside `Transform.rotate(angleRadians)` (so the
@@ -518,9 +695,11 @@ class _PageEditorState extends ConsumerState<PageEditor> {
     });
   }
 
-  /// Menu value for "send to back"; AI entries use their own list index, so
-  /// this sits outside that range.
+  /// Menu values for the editing actions; AI entries use their own list index,
+  /// so these sit outside that range.
   static const int _sendToBackAction = -1;
+  static const int _rotateClockwiseAction = -2;
+  static const int _rotateCounterClockwiseAction = -3;
 
   /// Assets a canvas action applies to: the whole selection when the asset
   /// acted on is part of it, otherwise just that asset. Mirrors [_moveAsset].
@@ -548,11 +727,57 @@ class _PageEditorState extends ConsumerState<PageEditor> {
     });
   }
 
+  /// Rotates [targets] a quarter turn as one rigid group about the centre of
+  /// their combined bounding box. A single asset is just the degenerate case:
+  /// its own centre is the group centre, so it spins in place.
+  ///
+  /// [constraints] supplies the canvas aspect ratio, without which a rotation
+  /// of the normalized coordinates would shear the group. See [rotateGroup].
+  void _rotateAssets(
+    List<Asset> targets,
+    double degrees,
+    BoxConstraints constraints,
+  ) {
+    if (targets.isEmpty) return;
+
+    final rotated = rotateGroup(
+      placements: [
+        for (final asset in targets)
+          AssetPlacement(
+            x: asset.coordinates.x,
+            y: asset.coordinates.y,
+            width: asset.size.width,
+            height: asset.size.height,
+            angle: asset.coordinates.angle,
+          ),
+      ],
+      degrees: degrees,
+      aspectRatio: constraints.maxWidth / constraints.maxHeight,
+    );
+
+    _saveToHistory();
+    _updateState(() {
+      for (var i = 0; i < targets.length; i++) {
+        targets[i].coordinates = Coordinates(
+          x: rotated[i].x,
+          y: rotated[i].y,
+          angle: rotated[i].angle,
+        );
+      }
+    });
+  }
+
   /// Right-click menu for an asset on the canvas.
   ///
   /// Editing actions are always available; the AI entries are appended only
   /// when MCP chat is up, preserving what the AI-only menu used to offer.
-  Future<void> _showAssetContextMenu(Asset asset, Offset globalPosition) async {
+  ///
+  /// [constraints] are the canvas's, needed by the rotate entries.
+  Future<void> _showAssetContextMenu(
+    Asset asset,
+    Offset globalPosition,
+    BoxConstraints constraints,
+  ) async {
     final aiItems = isMcpChatAvailable()
         ? buildEditorAssetMenuItems(asset)
         : const <AiMenuItem>[];
@@ -571,6 +796,26 @@ class _PageEditorState extends ConsumerState<PageEditor> {
         globalPosition.dy,
       ),
       items: [
+        PopupMenuItem<int>(
+          value: _rotateClockwiseAction,
+          child: ListTile(
+            leading: const Icon(Icons.rotate_right),
+            title: Text(targets.length > 1
+                ? 'Rotate ${targets.length} assets 90° clockwise'
+                : 'Rotate 90° clockwise'),
+            dense: true,
+          ),
+        ),
+        PopupMenuItem<int>(
+          value: _rotateCounterClockwiseAction,
+          child: ListTile(
+            leading: const Icon(Icons.rotate_left),
+            title: Text(targets.length > 1
+                ? 'Rotate ${targets.length} assets 90° counter-clockwise'
+                : 'Rotate 90° counter-clockwise'),
+            dense: true,
+          ),
+        ),
         PopupMenuItem<int>(
           value: _sendToBackAction,
           enabled: canSendToBack,
@@ -604,6 +849,10 @@ class _PageEditorState extends ConsumerState<PageEditor> {
 
     if (choice == _sendToBackAction) {
       _sendToBack(targets);
+    } else if (choice == _rotateClockwiseAction) {
+      _rotateAssets(targets, 90, constraints);
+    } else if (choice == _rotateCounterClockwiseAction) {
+      _rotateAssets(targets, -90, constraints);
     } else {
       await AiContextAction.runMenuItem(ref: ref, item: aiItems[choice]);
     }
@@ -767,7 +1016,9 @@ class _PageEditorState extends ConsumerState<PageEditor> {
                             onPanStart: (asset, details) {
                               _saveToHistory();
                             },
-                            onSecondaryTap: _showAssetContextMenu,
+                            onSecondaryTap: (asset, globalPosition) =>
+                                _showAssetContextMenu(
+                                    asset, globalPosition, constraints),
                             absorb: true,
                             selectedAssets: _selectedAssets,
                             proposedAssets: _proposedAssets,

--- a/test/pages/page_editor_rotate_group_test.dart
+++ b/test/pages/page_editor_rotate_group_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tfc/pages/page_editor.dart';
+
+/// `rotateGroup` backs the editor's "Rotate 90°" context-menu entries. It
+/// rotates a multi-selection rigidly about the centre of its bounding box:
+/// each asset spins on its own centre *and* orbits the group's.
+///
+/// Two properties matter most and are easy to break:
+///   - coordinates are normalized independently against a non-square canvas,
+///     so the maths has to un-scale x before rotating or the group shears;
+///   - turning a selection and turning it back must land where it started,
+///     which rules out the systematic error of `math.cos(pi / 2)`.
+void main() {
+  /// Square canvas keeps the aspect correction out of the way.
+  List<AssetPlacement> rotate(
+    List<AssetPlacement> placements,
+    double degrees, {
+    double aspectRatio = 1.0,
+  }) =>
+      rotateGroup(
+        placements: placements,
+        degrees: degrees,
+        aspectRatio: aspectRatio,
+      );
+
+  AssetPlacement at(double x, double y, {double? angle, double size = 0.1}) =>
+      AssetPlacement(x: x, y: y, width: size, height: size, angle: angle);
+
+  group('rotateGroup — single asset', () {
+    test('spins in place: its own centre is the group centre', () {
+      final result = rotate([at(0.25, 0.75)], 90);
+
+      expect(result.single.x, closeTo(0.25, 1e-12));
+      expect(result.single.y, closeTo(0.75, 1e-12));
+      expect(result.single.angle, 90);
+    });
+
+    test('accumulates onto an existing angle', () {
+      expect(rotate([at(0.5, 0.5, angle: 30)], 90).single.angle, 120);
+    });
+
+    test('wraps past a full turn', () {
+      expect(rotate([at(0.5, 0.5, angle: 300)], 90).single.angle, 30);
+      expect(rotate([at(0.5, 0.5, angle: 10)], -90).single.angle, 280);
+    });
+  });
+
+  group('rotateGroup — group geometry', () {
+    test('a horizontal row becomes a vertical column', () {
+      // Three assets in a row at y = 0.5, centred on x = 0.5.
+      final result = rotate([at(0.3, 0.5), at(0.5, 0.5), at(0.7, 0.5)], 90);
+
+      // Same centre, and the spread has moved from x to y.
+      for (final p in result) {
+        expect(p.x, closeTo(0.5, 1e-12));
+      }
+      expect(result.map((p) => p.y), [
+        closeTo(0.3, 1e-12),
+        closeTo(0.5, 1e-12),
+        closeTo(0.7, 1e-12),
+      ]);
+    });
+
+    test('clockwise sends the leftmost asset to the top', () {
+      // Screen y grows downward, so a +90° (clockwise) turn maps left→top.
+      final result = rotate([at(0.3, 0.5), at(0.7, 0.5)], 90);
+      expect(result[0].y, lessThan(result[1].y));
+    });
+
+    test('counter-clockwise sends the leftmost asset to the bottom', () {
+      final result = rotate([at(0.3, 0.5), at(0.7, 0.5)], -90);
+      expect(result[0].y, greaterThan(result[1].y));
+    });
+
+    test('every asset also spins, not just orbits', () {
+      final result = rotate([at(0.3, 0.5), at(0.7, 0.5)], 90);
+      expect(result.map((p) => p.angle), [90, 90]);
+    });
+
+    test('180° is a point reflection through the group centre', () {
+      final result = rotate([at(0.3, 0.4), at(0.7, 0.6)], 180);
+
+      expect(result[0].x, closeTo(0.7, 1e-12));
+      expect(result[0].y, closeTo(0.6, 1e-12));
+      expect(result[1].x, closeTo(0.3, 1e-12));
+      expect(result[1].y, closeTo(0.4, 1e-12));
+    });
+
+    test('preserves the distance between assets on a square canvas', () {
+      final before = [at(0.2, 0.3), at(0.6, 0.3)];
+      final after = rotate(before, 90);
+
+      final gap = (after[1].y - after[0].y).abs();
+      expect(gap, closeTo(0.4, 1e-12));
+    });
+  });
+
+  group('rotateGroup — aspect ratio', () {
+    test('a wide canvas does not shear the group', () {
+      // A 16:9 canvas: 0.1 of width is 16/9 as many pixels as 0.1 of height.
+      // A row spanning 0.4 of the width must come out spanning
+      // 0.4 * 16/9 of the height, or the layout has been squashed.
+      const aspect = 16 / 9;
+      final result =
+          rotate([at(0.3, 0.5), at(0.7, 0.5)], 90, aspectRatio: aspect);
+
+      final gapInHeights = (result[1].y - result[0].y).abs();
+      expect(gapInHeights, closeTo(0.4 * aspect, 1e-12));
+    });
+
+    test('naive normalized rotation would have squashed it', () {
+      // Guards the test above from silently passing if the aspect handling is
+      // dropped: without it the gap would come out as a plain 0.4.
+      const aspect = 16 / 9;
+      final result =
+          rotate([at(0.3, 0.5), at(0.7, 0.5)], 90, aspectRatio: aspect);
+
+      expect((result[1].y - result[0].y).abs(), isNot(closeTo(0.4, 1e-6)));
+    });
+
+    test('falls back to square for a degenerate canvas', () {
+      // A zero-height canvas gives aspectRatio = infinity; coordinates must
+      // stay finite rather than turning into NaN.
+      for (final aspect in [0.0, double.infinity, double.nan]) {
+        final result =
+            rotate([at(0.3, 0.5), at(0.7, 0.5)], 90, aspectRatio: aspect);
+        for (final p in result) {
+          expect(p.x.isFinite, isTrue, reason: 'aspect $aspect');
+          expect(p.y.isFinite, isTrue, reason: 'aspect $aspect');
+        }
+      }
+    });
+  });
+
+  group('rotateGroup — round trips', () {
+    test('clockwise then counter-clockwise restores the coordinates', () {
+      // Tolerance is a couple of ulps for the rounding in
+      // `centre + (p - centre)`; what must not survive is a *systematic*
+      // error, which is what the quarter-turn lookup table removes.
+      //
+      // The group is compact enough to fit the canvas in both orientations —
+      // one that does not gets nudged back on, which is a real (and tested
+      // below) departure from a clean round trip.
+      final before = [at(0.4, 0.35), at(0.55, 0.45), at(0.45, 0.6, angle: 30)];
+      final after = rotate(rotate(before, 90, aspectRatio: 16 / 9), -90,
+          aspectRatio: 16 / 9);
+
+      for (var i = 0; i < before.length; i++) {
+        expect(after[i].x, closeTo(before[i].x, 1e-15), reason: 'x of $i');
+        expect(after[i].y, closeTo(before[i].y, 1e-15), reason: 'y of $i');
+        expect(after[i].angle, before[i].angle, reason: 'angle of asset $i');
+      }
+    });
+
+    test('twenty quarter turns do not accumulate drift', () {
+      // Five full revolutions: a per-turn bias would show up as ~20x the
+      // single-turn error, so the same tolerance that fits one turn is a
+      // real check that nothing is creeping.
+      final before = [at(0.25, 0.25), at(0.4, 0.6)];
+      var after = before;
+      for (var i = 0; i < 20; i++) {
+        after = rotate(after, 90);
+      }
+
+      for (var i = 0; i < before.length; i++) {
+        expect(after[i].x, closeTo(before[i].x, 1e-15));
+        expect(after[i].y, closeTo(before[i].y, 1e-15));
+        expect(after[i].angle, before[i].angle);
+      }
+    });
+
+    test('assets of differing sizes round trip too', () {
+      // The bounding box is built from rotated extents; if it were not, a
+      // mixed-size group's centre would drift on each turn.
+      final before = [
+        AssetPlacement(x: 0.3, y: 0.4, width: 0.4, height: 0.05),
+        AssetPlacement(x: 0.6, y: 0.5, width: 0.05, height: 0.3),
+      ];
+      final after = rotate(rotate(before, 90), -90);
+
+      for (var i = 0; i < before.length; i++) {
+        expect(after[i].x, closeTo(before[i].x, 1e-12));
+        expect(after[i].y, closeTo(before[i].y, 1e-12));
+      }
+    });
+  });
+
+  group('rotateGroup — angle nullability', () {
+    test('leaves a never-rotated asset null when it returns to 0', () {
+      // AssetStack only applies the page mirror transform to assets with a
+      // non-null angle, so null must survive a round trip.
+      final after = rotate(rotate([at(0.5, 0.5)], 90), -90);
+      expect(after.single.angle, isNull);
+    });
+
+    test('collapses an explicit 0 to null', () {
+      // The documented trade-off of the rule above: null is the canonical
+      // representation of "no rotation", so an explicit 0 does not survive.
+      final after = rotate([at(0.5, 0.5, angle: 0)], 0);
+      expect(after.single.angle, isNull);
+    });
+
+    test('a null angle becomes explicit once actually rotated', () {
+      expect(rotate([at(0.5, 0.5)], 90).single.angle, 90);
+    });
+  });
+
+  group('rotateGroup — staying on the canvas', () {
+    test('translates a group that would rotate off the top edge', () {
+      // A wide, short row near the top: rotating it makes it tall, and a
+      // naive rotation would push half of it above y = 0.
+      final result = rotate([
+        AssetPlacement(x: 0.5, y: 0.1, width: 0.1, height: 0.05),
+        AssetPlacement(x: 0.5, y: 0.1, width: 0.6, height: 0.05),
+      ], 90);
+
+      for (final p in result) {
+        expect(p.y, greaterThanOrEqualTo(0.0));
+        expect(p.y, lessThanOrEqualTo(1.0));
+      }
+    });
+
+    test('shifts the group as a unit, preserving relative spacing', () {
+      // Clamping each asset independently would pile them onto the edge; the
+      // gap between them has to survive.
+      final result = rotate([at(0.1, 0.1), at(0.5, 0.1)], 90);
+
+      final gap = (result[1].y - result[0].y).abs();
+      expect(gap, closeTo(0.4, 1e-12));
+      for (final p in result) {
+        expect(p.x, inInclusiveRange(0.0, 1.0));
+        expect(p.y, inInclusiveRange(0.0, 1.0));
+      }
+    });
+
+    test('keeps centres on the canvas when the group is too big to fit', () {
+      final result = rotate([
+        AssetPlacement(x: 0.5, y: 0.5, width: 0.95, height: 0.05),
+        AssetPlacement(x: 0.1, y: 0.5, width: 0.05, height: 0.05),
+      ], 90);
+
+      for (final p in result) {
+        expect(p.x, inInclusiveRange(0.0, 1.0));
+        expect(p.y, inInclusiveRange(0.0, 1.0));
+      }
+    });
+
+    test('a group too tall for the canvas once rotated is nudged back on', () {
+      // A full-width row on a 16:9 canvas turns into a column 1.24 canvas
+      // heights tall — it cannot fit, so the trailing asset lands on the
+      // bottom edge rather than off-canvas, and the turn is no longer a clean
+      // round trip. Documented rather than fixed: the alternative leaves
+      // assets somewhere the operator cannot grab them.
+      const aspect = 16 / 9;
+      final before = [at(0.15, 0.5), at(0.85, 0.5)];
+      final rotated = rotate(before, 90, aspectRatio: aspect);
+
+      for (final p in rotated) {
+        expect(p.y, inInclusiveRange(0.0, 1.0));
+      }
+      // Still ordered, still spread out — just compressed to fit.
+      expect(rotated[0].y, lessThan(rotated[1].y));
+
+      final back = rotate(rotated, -90, aspectRatio: aspect);
+      expect(back[0].x, isNot(closeTo(before[0].x, 1e-6)));
+    });
+
+    test('a group already well inside the canvas is not moved', () {
+      final result = rotate([at(0.4, 0.45), at(0.6, 0.55)], 90);
+
+      // Centre of the pair is (0.5, 0.5) and stays there.
+      expect((result[0].x + result[1].x) / 2, closeTo(0.5, 1e-12));
+      expect((result[0].y + result[1].y) / 2, closeTo(0.5, 1e-12));
+    });
+  });
+
+  group('rotateGroup — edge cases', () {
+    test('an empty selection returns empty', () {
+      expect(rotate([], 90), isEmpty);
+    });
+
+    test('does not mutate the input', () {
+      final before = [at(0.3, 0.4, angle: 15)];
+      rotate(before, 90);
+
+      expect(before.single.x, 0.3);
+      expect(before.single.y, 0.4);
+      expect(before.single.angle, 15);
+    });
+
+    test('sizes pass through untouched', () {
+      final result =
+          rotate([AssetPlacement(x: 0.5, y: 0.5, width: 0.4, height: 0.1)], 90);
+
+      // Rotation is expressed through the angle; the stored extents stay in
+      // the asset's own frame, as AssetStack expects.
+      expect(result.single.width, 0.4);
+      expect(result.single.height, 0.1);
+    });
+
+    test('0° is a no-op', () {
+      final before = [at(0.3, 0.4), at(0.7, 0.6)];
+      final after = rotate(before, 0);
+
+      for (var i = 0; i < before.length; i++) {
+        expect(after[i].x, closeTo(before[i].x, 1e-12));
+        expect(after[i].y, closeTo(before[i].y, 1e-12));
+        expect(after[i].angle, isNull);
+      }
+    });
+
+    test('handles a non-quarter turn', () {
+      // The menu only offers quarter turns, but the helper is general.
+      final result = rotate([at(0.5, 0.3), at(0.5, 0.7)], 45);
+      expect(result[0].angle, 45);
+      // Clockwise swings the upper asset out to the right and down; the
+      // pair ends up on the anti-diagonal.
+      expect(result[0].x, greaterThan(result[1].x));
+      expect(result[0].y, lessThan(result[1].y));
+    });
+  });
+}

--- a/test/widgets/page_editor_rotate_selection_test.dart
+++ b/test/widgets/page_editor_rotate_selection_test.dart
@@ -1,0 +1,373 @@
+/// End-to-end cover for rotating a multi-selection in the page editor.
+///
+/// The maths lives in `rotateGroup` and is unit-tested in
+/// test/pages/page_editor_rotate_group_test.dart. What those tests cannot see
+/// is the wiring: that the context menu offers the entries, that they act on
+/// the whole marquee selection rather than the asset under the cursor, that
+/// the canvas aspect ratio actually reaches the maths, and that the result is
+/// what gets persisted.
+///
+/// So this drives the real editor: marquee-select a row of boxes, right-click,
+/// pick "Rotate 3 assets 90° clockwise", then read the saved JSON back.
+library;
+
+import 'dart:convert';
+import 'dart:io' show Platform;
+
+import 'package:beamer/beamer.dart';
+import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:tfc_dart/core/preferences.dart';
+
+import 'package:tfc/models/menu_item.dart';
+import 'package:tfc/page_creator/assets/common.dart';
+import 'package:tfc/page_creator/assets/drawn_box.dart';
+import 'package:tfc/page_creator/page.dart';
+import 'package:tfc/pages/page_editor.dart';
+import 'package:tfc/pages/page_view.dart';
+import 'package:tfc/providers/alarm.dart';
+import 'package:tfc/providers/database.dart';
+import 'package:tfc/providers/page_manager.dart';
+import 'package:tfc/route_registry.dart';
+
+/// Minimal in-memory [PreferencesApi] so the editor can load and save.
+/// Doubles as the read-back channel: whatever the save button writes here is
+/// what the operator would get on reload.
+class _FakePreferences implements PreferencesApi {
+  final Map<String, Object> _store = {};
+
+  @override
+  Future<String?> getString(String key) async => _store[key] as String?;
+  @override
+  Future<void> setString(String key, String value) async => _store[key] = value;
+  @override
+  Future<Set<String>> getKeys({Set<String>? allowList}) async =>
+      _store.keys.toSet();
+  @override
+  Future<Map<String, Object?>> getAll({Set<String>? allowList}) async =>
+      Map.from(_store);
+  @override
+  Future<bool?> getBool(String key) async => _store[key] as bool?;
+  @override
+  Future<int?> getInt(String key) async => _store[key] as int?;
+  @override
+  Future<double?> getDouble(String key) async => _store[key] as double?;
+  @override
+  Future<List<String>?> getStringList(String key) async =>
+      _store[key] as List<String>?;
+  @override
+  Future<bool> containsKey(String key) async => _store.containsKey(key);
+  @override
+  Future<void> setBool(String key, bool value) async => _store[key] = value;
+  @override
+  Future<void> setInt(String key, int value) async => _store[key] = value;
+  @override
+  Future<void> setDouble(String key, double value) async => _store[key] = value;
+  @override
+  Future<void> setStringList(String key, List<String> value) async =>
+      _store[key] = value;
+  @override
+  Future<void> remove(String key) async => _store.remove(key);
+  @override
+  Future<void> clear({Set<String>? allowList}) async {
+    if (allowList == null) {
+      _store.clear();
+    } else {
+      _store.removeWhere((k, _) => allowList.contains(k));
+    }
+  }
+}
+
+/// A box at ([x], [y]). Deliberately non-square so a quarter turn is visible
+/// in the persisted extents as well as the coordinates.
+DrawnBoxConfig _box(double x, double y, {double? angle}) {
+  return DrawnBoxConfig.preview()
+    ..coordinates = Coordinates(x: x, y: y, angle: angle)
+    ..size = const RelativeSize(width: 0.12, height: 0.06);
+}
+
+PageManager _managerWith(List<Asset> assets, _FakePreferences prefs) {
+  return PageManager(
+    prefs: prefs,
+    pages: {
+      '/': AssetPage(
+        menuItem: const MenuItem(label: 'Home', path: '/', icon: Icons.home),
+        assets: assets,
+        mirroringDisabled: true,
+        navigationPriority: 0,
+      ),
+    },
+  );
+}
+
+/// The editor lives inside `BaseScaffold`, which reads the current Beamer
+/// location during build, so it needs a router above it.
+class _EditorLocation extends BeamLocation<BeamState> {
+  _EditorLocation()
+      : super(RouteInformation(uri: Uri.parse('/advanced/page-editor')));
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) => const [
+        BeamPage(key: ValueKey('page-editor'), child: PageEditor()),
+      ];
+
+  @override
+  List<Pattern> get pathPatterns => ['/advanced/page-editor'];
+}
+
+Widget _buildEditor(PageManager manager) {
+  final routerDelegate = BeamerDelegate(
+    locationBuilder: (routeInformation, _) => _EditorLocation(),
+  );
+  return ProviderScope(
+    overrides: [
+      pageManagerProvider.overrideWith((ref) async => manager),
+      // Keep the editor off the database / PLC / alarm stack: BaseScaffold
+      // only needs these to decide between the clock and the alarm banner.
+      databaseProvider.overrideWith((ref) async => null),
+      alarmManProvider
+          .overrideWith((ref) => throw StateError('No AlarmMan in tests')),
+    ],
+    child: BeamerProvider(
+      routerDelegate: routerDelegate,
+      child: MaterialApp.router(
+        routerDelegate: routerDelegate,
+        routeInformationParser: BeamerParser(),
+      ),
+    ),
+  );
+}
+
+/// A point at relative ([fx], [fy]) within the rendered canvas.
+Offset _onCanvas(WidgetTester tester, double fx, double fy) {
+  final r = tester.getRect(find.byType(AssetStack));
+  return Offset(r.left + r.width * fx, r.top + r.height * fy);
+}
+
+/// The canvas's width / height — the aspect ratio the rotation has to correct
+/// for, recovered from the live layout rather than assumed.
+double _canvasAspect(WidgetTester tester) {
+  final r = tester.getRect(find.byType(AssetStack));
+  return r.width / r.height;
+}
+
+/// Switches the editor from pan mode into marquee-select mode.
+Future<void> _enterSelectMode(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.pan_tool));
+  await tester.pumpAndSettle();
+  expect(find.byIcon(Icons.select_all), findsOneWidget,
+      reason: 'the mode button should now show select mode');
+}
+
+/// Rubber-bands from ([x1], [y1]) to ([x2], [y2]) in canvas-relative units.
+Future<void> _marquee(
+    WidgetTester tester, double x1, double y1, double x2, double y2) async {
+  final gesture = await tester.startGesture(_onCanvas(tester, x1, y1));
+  await tester.pump();
+  // Two moves: the first crosses the slop, the second lands on the corner.
+  await gesture.moveTo(_onCanvas(tester, (x1 + x2) / 2, (y1 + y2) / 2));
+  await tester.pump();
+  await gesture.moveTo(_onCanvas(tester, x2, y2));
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+/// Presses the editor's undo shortcut. It is keyboard-only, and the editor
+/// picks the modifier from `Platform`, so the test has to match.
+Future<void> _pressUndo(WidgetTester tester) async {
+  final modifier = Platform.isMacOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+  await tester.sendKeyDownEvent(modifier);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(modifier);
+  await tester.pumpAndSettle();
+}
+
+/// Saves, then returns the persisted assets of the home page in page order.
+Future<List<Map<String, dynamic>>> _saveAndReadBack(
+    WidgetTester tester, _FakePreferences prefs) async {
+  await tester.tap(find.byIcon(Icons.save));
+  await tester.pumpAndSettle();
+
+  // The manager writes the whole page map under a single key; find the entry
+  // that parses as one and contains our page.
+  for (final value in prefs._store.values) {
+    if (value is! String) continue;
+    final decoded = jsonDecode(value);
+    if (decoded is! Map<String, dynamic>) continue;
+    final page = decoded['/'];
+    if (page is Map<String, dynamic> && page['assets'] is List) {
+      return (page['assets'] as List).cast<Map<String, dynamic>>();
+    }
+  }
+  fail('no saved page found in preferences: ${prefs._store.keys}');
+}
+
+Map<String, dynamic> _coords(Map<String, dynamic> asset) =>
+    asset['coordinates'] as Map<String, dynamic>;
+
+void main() {
+  setUp(() {
+    // The asset canvas constructs SharedPreferencesAsync directly.
+    SharedPreferencesAsyncPlatform.instance =
+        InMemorySharedPreferencesAsync.empty();
+
+    // BaseScaffold renders a NavigationBar from the registry, which asserts on
+    // fewer than two destinations.
+    final registry = RouteRegistry();
+    registry.menuItems.clear();
+    registry.addMenuItem(
+        const MenuItem(label: 'Home', path: '/', icon: Icons.home));
+    registry.addMenuItem(const MenuItem(
+        label: 'Advanced', path: '/advanced', icon: Icons.settings));
+  });
+
+  /// A row of three boxes across the middle of the canvas.
+  Future<_FakePreferences> pumpRow(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final prefs = _FakePreferences();
+    await tester.pumpWidget(_buildEditor(_managerWith(
+      [_box(0.3, 0.5), _box(0.5, 0.5), _box(0.7, 0.5)],
+      prefs,
+    )));
+    await tester.pumpAndSettle();
+    expect(find.byType(DrawnBox), findsNWidgets(3));
+    return prefs;
+  }
+
+  testWidgets('rotates a marquee selection as a group', (tester) async {
+    final prefs = await pumpRow(tester);
+    final aspect = _canvasAspect(tester);
+    // The spacing assertion below is only meaningful on a non-square canvas —
+    // on a square one it would pass with the aspect handling ripped out.
+    expect(aspect, greaterThan(1.5),
+        reason: 'the editor canvas should be wide (it renders 16:9)');
+
+    await _enterSelectMode(tester);
+    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
+
+    // Right-click the middle box. The label proves all three are selected —
+    // if the marquee had missed, this would read "Rotate 90° clockwise".
+    await tester.tapAt(_onCanvas(tester, 0.5, 0.5), buttons: kSecondaryButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Rotate 3 assets 90° clockwise'), findsOneWidget);
+
+    await tester.tap(find.text('Rotate 3 assets 90° clockwise'));
+    await tester.pumpAndSettle();
+
+    final saved = await _saveAndReadBack(tester, prefs);
+    expect(saved, hasLength(3));
+
+    // The row is now a column through the group's centre.
+    for (final asset in saved) {
+      expect(_coords(asset)['x'] as double, closeTo(0.5, 1e-9));
+    }
+
+    // Clockwise: the leftmost box is now the topmost.
+    final ys = [for (final a in saved) _coords(a)['y'] as double];
+    expect(ys[0], lessThan(ys[1]));
+    expect(ys[1], lessThan(ys[2]));
+
+    // The spacing is preserved *in pixels*, which is the whole point of the
+    // aspect correction: 0.2 of the canvas width has to become 0.2 * aspect
+    // of its height. Without the correction this would come out as 0.2.
+    expect(ys[1] - ys[0], closeTo(0.2 * aspect, 1e-9));
+    expect(ys[2] - ys[1], closeTo(0.2 * aspect, 1e-9));
+
+    // ...and every box spun, not just orbited.
+    for (final asset in saved) {
+      expect(_coords(asset)['angle'], 90);
+    }
+  });
+
+  testWidgets('rotating back restores the original layout', (tester) async {
+    final prefs = await pumpRow(tester);
+
+    await _enterSelectMode(tester);
+    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
+
+    Future<void> rotate(String label) async {
+      await tester.tapAt(_onCanvas(tester, 0.5, 0.5),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+    }
+
+    await rotate('Rotate 3 assets 90° clockwise');
+    // The selection survives the rotation, so the second turn hits the same
+    // three assets — worth asserting, since losing it would silently make the
+    // menu act on one box.
+    await rotate('Rotate 3 assets 90° counter-clockwise');
+
+    final saved = await _saveAndReadBack(tester, prefs);
+    final xs = [for (final a in saved) _coords(a)['x'] as double];
+    final ys = [for (final a in saved) _coords(a)['y'] as double];
+
+    expect(xs[0], closeTo(0.3, 1e-9));
+    expect(xs[1], closeTo(0.5, 1e-9));
+    expect(xs[2], closeTo(0.7, 1e-9));
+    for (final y in ys) {
+      expect(y, closeTo(0.5, 1e-9));
+    }
+    // Back to "never rotated", so mirrored pages behave as they did before.
+    for (final asset in saved) {
+      expect(_coords(asset)['angle'], isNull);
+    }
+  });
+
+  testWidgets('undo reverts a group rotation in one step', (tester) async {
+    final prefs = await pumpRow(tester);
+
+    await _enterSelectMode(tester);
+    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
+
+    await tester.tapAt(_onCanvas(tester, 0.5, 0.5), buttons: kSecondaryButton);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rotate 3 assets 90° clockwise'));
+    await tester.pumpAndSettle();
+
+    await _pressUndo(tester);
+
+    final saved = await _saveAndReadBack(tester, prefs);
+    expect([for (final a in saved) _coords(a)['x'] as double],
+        [closeTo(0.3, 1e-9), closeTo(0.5, 1e-9), closeTo(0.7, 1e-9)]);
+    for (final asset in saved) {
+      expect(_coords(asset)['angle'], isNull);
+    }
+  });
+
+  testWidgets('an unselected asset rotates on its own', (tester) async {
+    // Outside select mode there is no selection, so the menu acts on just the
+    // asset under the cursor — and a single asset spins in place.
+    final prefs = await pumpRow(tester);
+
+    await tester.tapAt(_onCanvas(tester, 0.3, 0.5), buttons: kSecondaryButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Rotate 90° clockwise'), findsOneWidget,
+        reason: 'no selection, so the label should be singular');
+
+    await tester.tap(find.text('Rotate 90° clockwise'));
+    await tester.pumpAndSettle();
+
+    final saved = await _saveAndReadBack(tester, prefs);
+    expect(_coords(saved[0])['angle'], 90);
+    expect(_coords(saved[0])['x'] as double, closeTo(0.3, 1e-9));
+    expect(_coords(saved[0])['y'] as double, closeTo(0.5, 1e-9));
+
+    // The other two are untouched.
+    expect(_coords(saved[1])['angle'], isNull);
+    expect(_coords(saved[2])['angle'], isNull);
+  });
+}


### PR DESCRIPTION
## What

Right-clicking a selection in the page editor now offers **Rotate N assets 90° clockwise / counter-clockwise**.

Rotation was single-asset only, and reachable only by typing into the `Angle (°)` field in an asset's config dialog — which ~20 asset types don't even show. Re-orienting a row of conveyors meant editing each asset by hand, and assets with the field hidden couldn't be rotated at all.

The new entries reuse `_actionTargets`, so they act on the whole selection when the clicked asset is part of it and on that asset alone otherwise — the same rule as "Send to back" and dragging. Rendering already honours `coordinates.angle` for every asset type (`page_view.dart:251`), so this works regardless of whether the config dialog exposes the field. Undo-backed like the other canvas actions.

The selection rotates **rigidly**: each asset spins on its own centre *and* orbits the group's bounding-box centre.

```
before:              after +90°:

  [A]  [B]  [C]           [A']
                          [B']
                          [C']
```

## Three things the maths has to get right

- **Aspect ratio is load-bearing.** `x` and `y` are normalized independently against a non-square canvas, so rotating normalized coordinates directly would shear the group — a row spanning 40% of a 16:9 canvas's width must come out spanning 71% of its height. The maths runs in canvas-height units, which is why the canvas `constraints` now have to reach the context menu.
- **The group centre must not drift.** The bounding box is built from each asset's *rotated* extents, so a quarter turn maps the box onto itself. Combined with exact quarter-turn factors (`math.cos(pi / 2)` is 6.1e-17, not 0) there's no direction for error to accumulate in over repeated turns — verified over 20 consecutive turns.
- **Off-canvas groups are translated back as a unit**, not clamped per asset, which would collapse the layout. A group too large to fit is edge-aligned, and centres are clamped only as a last resort so nothing lands somewhere the operator can't grab it.

## One deliberate trade-off

An angle back at zero is stored as `null`, not `0.0`. `AssetStack` only applies the page's mirror transform to assets with a non-null angle (`page_view.dart:298`), so a CW-then-CCW round trip had to restore the `null` or never-rotated assets would start flipping on mirrored pages. The cost is that an angle stored explicitly as `0` collapses to `null`.

## Testing

- **28 unit tests** for the geometry (`test/pages/page_editor_rotate_group_test.dart`) — group rotation, aspect correction, round trips, null handling, canvas containment, degenerate inputs.
- **4 end-to-end tests** driving the real editor (`test/widgets/page_editor_rotate_selection_test.dart`) — marquee-select three boxes, right-click, pick the menu entry, then read the **saved JSON** back. Also covers rotating back, undo, and the unselected-asset case.
- **Mutation-checked**: dropping the aspect correction fails 4 tests; making the action ignore the selection fails 2. Neither passes silently.
- Full suite green: **2256 passed**, 6 pre-existing skips. No new analyzer issues (the two remaining in `page_editor.dart` are on `main`; the `depend_on_referenced_packages` infos match the sibling `page_editor_section_test.dart`).

## Not included

Only the context-menu entry, per the agreed scope — no keyboard shortcut, set-angle dialog, or on-canvas drag handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)