### PR TITLE
feat(page-editor): align a multi-selection horizontally or vertically

### DIFF
--- a/lib/pages/page_editor.dart
+++ b/lib/pages/page_editor.dart
@@ -271,6 +271,71 @@ List<AssetPlacement> rotateGroup({
   ];
 }
 
+/// The axis a selection is lined up along.
+enum AlignAxis {
+  /// Assets end up in a horizontal row: one shared y, x untouched.
+  horizontal,
+
+  /// Assets end up in a vertical column: one shared x, y untouched.
+  vertical,
+}
+
+/// The coordinate [axis] alignment moves, for each of [placements].
+Iterable<double> _alignedCoordinates(
+        List<AssetPlacement> placements, AlignAxis axis) =>
+    placements.map((p) => axis == AlignAxis.horizontal ? p.y : p.x);
+
+/// Lines [placements] up on [axis], moving every asset's centre onto the
+/// midpoint between the two outermost centres.
+///
+/// Centres, not edges: assets of different sizes end up with their middles on
+/// one line and their edges ragged. That is what makes this the one selection
+/// action that needs no canvas aspect ratio — it writes a constant into a
+/// single normalized axis and leaves the other alone, so there is no
+/// cross-axis maths to get wrong.
+///
+/// The line is the midpoint of the extremes rather than the mean, matching
+/// what a drawing tool does: the two outermost assets move symmetrically
+/// toward each other instead of the line being dragged around by whichever
+/// side happens to be crowded.
+///
+/// Returns a new list positionally matching [placements]; nothing is mutated.
+@visibleForTesting
+List<AssetPlacement> alignGroup({
+  required List<AssetPlacement> placements,
+  required AlignAxis axis,
+}) {
+  if (placements.isEmpty) return const [];
+
+  final coordinates = _alignedCoordinates(placements, axis);
+  final line =
+      (coordinates.reduce(math.min) + coordinates.reduce(math.max)) / 2;
+
+  return [
+    for (final p in placements)
+      AssetPlacement(
+        x: axis == AlignAxis.vertical ? line : p.x,
+        y: axis == AlignAxis.horizontal ? line : p.y,
+        width: p.width,
+        height: p.height,
+        angle: p.angle,
+      ),
+  ];
+}
+
+/// Whether [placements] already sit on one line along [axis], so the menu
+/// entry can be disabled rather than pushing a no-op onto the undo history.
+///
+/// Exact equality is the right test, not a tolerance: [alignGroup] writes the
+/// identical value into every asset, so a selection it has just aligned reads
+/// back as aligned. Fewer than two assets have nothing to line up.
+@visibleForTesting
+bool isAlreadyAligned(List<AssetPlacement> placements, AlignAxis axis) {
+  if (placements.length < 2) return true;
+  final coordinates = _alignedCoordinates(placements, axis);
+  return coordinates.every((c) => c == coordinates.first);
+}
+
 /// Projects a drag delta from the rotated GestureDetector's local frame
 /// back into the canvas (parent) frame. The editor's per-asset
 /// GestureDetector lives inside `Transform.rotate(angleRadians)` (so the
@@ -701,6 +766,8 @@ class _PageEditorState extends ConsumerState<PageEditor> {
   static const int _sendToBackAction = -1;
   static const int _rotateClockwiseAction = -2;
   static const int _rotateCounterClockwiseAction = -3;
+  static const int _alignHorizontalAction = -4;
+  static const int _alignVerticalAction = -5;
 
   /// Assets a canvas action applies to: the whole selection when the asset
   /// acted on is part of it, otherwise just that asset. Mirrors [_moveAsset].
@@ -728,6 +795,45 @@ class _PageEditorState extends ConsumerState<PageEditor> {
     });
   }
 
+  /// [targets] as placements, for the geometry helpers.
+  List<AssetPlacement> _placements(List<Asset> targets) => [
+        for (final asset in targets)
+          AssetPlacement(
+            x: asset.coordinates.x,
+            y: asset.coordinates.y,
+            width: asset.size.width,
+            height: asset.size.height,
+            angle: asset.coordinates.angle,
+          ),
+      ];
+
+  /// Writes [placements] back onto [targets], which must line up positionally.
+  void _applyPlacements(List<Asset> targets, List<AssetPlacement> placements) {
+    _saveToHistory();
+    _updateState(() {
+      for (var i = 0; i < targets.length; i++) {
+        targets[i].coordinates = Coordinates(
+          x: placements[i].x,
+          y: placements[i].y,
+          angle: placements[i].angle,
+        );
+      }
+    });
+  }
+
+  /// False when [targets] already sit on one line along [axis], so the menu
+  /// entry can be disabled. Mirrors [_canSendToBack].
+  bool _canAlign(List<Asset> targets, AlignAxis axis) =>
+      !isAlreadyAligned(_placements(targets), axis);
+
+  /// Lines [targets] up on [axis], centre points onto the selection's middle.
+  void _alignAssets(List<Asset> targets, AlignAxis axis) {
+    final placements = _placements(targets);
+    if (isAlreadyAligned(placements, axis)) return;
+
+    _applyPlacements(targets, alignGroup(placements: placements, axis: axis));
+  }
+
   /// Rotates [targets] a quarter turn as one rigid group about the centre of
   /// their combined bounding box. A single asset is just the degenerate case:
   /// its own centre is the group centre, so it spins in place.
@@ -741,31 +847,14 @@ class _PageEditorState extends ConsumerState<PageEditor> {
   ) {
     if (targets.isEmpty) return;
 
-    final rotated = rotateGroup(
-      placements: [
-        for (final asset in targets)
-          AssetPlacement(
-            x: asset.coordinates.x,
-            y: asset.coordinates.y,
-            width: asset.size.width,
-            height: asset.size.height,
-            angle: asset.coordinates.angle,
-          ),
-      ],
-      degrees: degrees,
-      aspectRatio: constraints.maxWidth / constraints.maxHeight,
+    _applyPlacements(
+      targets,
+      rotateGroup(
+        placements: _placements(targets),
+        degrees: degrees,
+        aspectRatio: constraints.maxWidth / constraints.maxHeight,
+      ),
     );
-
-    _saveToHistory();
-    _updateState(() {
-      for (var i = 0; i < targets.length; i++) {
-        targets[i].coordinates = Coordinates(
-          x: rotated[i].x,
-          y: rotated[i].y,
-          angle: rotated[i].angle,
-        );
-      }
-    });
   }
 
   /// Right-click menu for an asset on the canvas.
@@ -785,6 +874,8 @@ class _PageEditorState extends ConsumerState<PageEditor> {
 
     final targets = _actionTargets(asset);
     final canSendToBack = _canSendToBack(targets);
+    final canAlignHorizontal = _canAlign(targets, AlignAxis.horizontal);
+    final canAlignVertical = _canAlign(targets, AlignAxis.vertical);
 
     final choice = await showMenu<int>(
       context: context,
@@ -815,6 +906,34 @@ class _PageEditorState extends ConsumerState<PageEditor> {
                 ? 'Rotate ${targets.length} assets 90° counter-clockwise'
                 : 'Rotate 90° counter-clockwise'),
             dense: true,
+          ),
+        ),
+        // The icon names read backwards: `align_vertical_center` draws a
+        // horizontal reference line, which is what lining assets up into a
+        // row looks like. Pair each entry with the line it produces, not with
+        // the word in the icon name.
+        PopupMenuItem<int>(
+          value: _alignHorizontalAction,
+          enabled: canAlignHorizontal,
+          child: ListTile(
+            leading: const Icon(Icons.align_vertical_center),
+            title: Text(targets.length > 1
+                ? 'Align ${targets.length} assets horizontally'
+                : 'Align horizontally'),
+            dense: true,
+            enabled: canAlignHorizontal,
+          ),
+        ),
+        PopupMenuItem<int>(
+          value: _alignVerticalAction,
+          enabled: canAlignVertical,
+          child: ListTile(
+            leading: const Icon(Icons.align_horizontal_center),
+            title: Text(targets.length > 1
+                ? 'Align ${targets.length} assets vertically'
+                : 'Align vertically'),
+            dense: true,
+            enabled: canAlignVertical,
           ),
         ),
         PopupMenuItem<int>(
@@ -854,6 +973,10 @@ class _PageEditorState extends ConsumerState<PageEditor> {
       _rotateAssets(targets, 90, constraints);
     } else if (choice == _rotateCounterClockwiseAction) {
       _rotateAssets(targets, -90, constraints);
+    } else if (choice == _alignHorizontalAction) {
+      _alignAssets(targets, AlignAxis.horizontal);
+    } else if (choice == _alignVerticalAction) {
+      _alignAssets(targets, AlignAxis.vertical);
     } else {
       await AiContextAction.runMenuItem(ref: ref, item: aiItems[choice]);
     }

--- a/test/helpers/page_editor_harness.dart
+++ b/test/helpers/page_editor_harness.dart
@@ -1,0 +1,266 @@
+/// Shared scaffolding for end-to-end page editor tests.
+///
+/// The editor is pumpable, but only with a fair amount of setup: it sits
+/// inside `BaseScaffold`, which reads the current Beamer location and the
+/// route registry during build, and it loads and saves through a
+/// [PreferencesApi]. Anything that drives the real editor needs all of it, so
+/// it lives here rather than being copied per test file.
+///
+/// The save-and-read-back path is the useful part: [FakeEditorPreferences] is
+/// what the editor persists into, so a test can assert on the JSON an operator
+/// would actually get back on reload rather than on widget positions.
+library;
+
+import 'dart:convert';
+import 'dart:io' show Platform;
+
+import 'package:beamer/beamer.dart';
+import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:tfc_dart/core/preferences.dart';
+
+import 'package:tfc/models/menu_item.dart';
+import 'package:tfc/page_creator/assets/common.dart';
+import 'package:tfc/page_creator/assets/drawn_box.dart';
+import 'package:tfc/page_creator/page.dart';
+import 'package:tfc/pages/page_editor.dart';
+import 'package:tfc/pages/page_view.dart';
+import 'package:tfc/providers/alarm.dart';
+import 'package:tfc/providers/database.dart';
+import 'package:tfc/providers/page_manager.dart';
+import 'package:tfc/route_registry.dart';
+
+/// Minimal in-memory [PreferencesApi] so the editor can load and save.
+/// Doubles as the read-back channel for [saveAndReadBack].
+class FakeEditorPreferences implements PreferencesApi {
+  final Map<String, Object> _store = {};
+
+  @override
+  Future<String?> getString(String key) async => _store[key] as String?;
+  @override
+  Future<void> setString(String key, String value) async => _store[key] = value;
+  @override
+  Future<Set<String>> getKeys({Set<String>? allowList}) async =>
+      _store.keys.toSet();
+  @override
+  Future<Map<String, Object?>> getAll({Set<String>? allowList}) async =>
+      Map.from(_store);
+  @override
+  Future<bool?> getBool(String key) async => _store[key] as bool?;
+  @override
+  Future<int?> getInt(String key) async => _store[key] as int?;
+  @override
+  Future<double?> getDouble(String key) async => _store[key] as double?;
+  @override
+  Future<List<String>?> getStringList(String key) async =>
+      _store[key] as List<String>?;
+  @override
+  Future<bool> containsKey(String key) async => _store.containsKey(key);
+  @override
+  Future<void> setBool(String key, bool value) async => _store[key] = value;
+  @override
+  Future<void> setInt(String key, int value) async => _store[key] = value;
+  @override
+  Future<void> setDouble(String key, double value) async => _store[key] = value;
+  @override
+  Future<void> setStringList(String key, List<String> value) async =>
+      _store[key] = value;
+  @override
+  Future<void> remove(String key) async => _store.remove(key);
+  @override
+  Future<void> clear({Set<String>? allowList}) async {
+    if (allowList == null) {
+      _store.clear();
+    } else {
+      _store.removeWhere((k, _) => allowList.contains(k));
+    }
+  }
+}
+
+/// A box at ([x], [y]). Deliberately non-square, so orientation is visible in
+/// the persisted extents and not just the coordinates.
+DrawnBoxConfig editorBox(double x, double y, {double? angle}) {
+  return DrawnBoxConfig.preview()
+    ..coordinates = Coordinates(x: x, y: y, angle: angle)
+    ..size = const RelativeSize(width: 0.12, height: 0.06);
+}
+
+/// A one-page manager holding [assets], saving into [prefs].
+PageManager editorManagerWith(List<Asset> assets, FakeEditorPreferences prefs) {
+  return PageManager(
+    prefs: prefs,
+    pages: {
+      '/': AssetPage(
+        menuItem: const MenuItem(label: 'Home', path: '/', icon: Icons.home),
+        assets: assets,
+        mirroringDisabled: true,
+        navigationPriority: 0,
+      ),
+    },
+  );
+}
+
+/// The editor lives inside `BaseScaffold`, which reads the current Beamer
+/// location during build, so it needs a router above it.
+class _EditorLocation extends BeamLocation<BeamState> {
+  _EditorLocation()
+      : super(RouteInformation(uri: Uri.parse('/advanced/page-editor')));
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) => const [
+        BeamPage(key: ValueKey('page-editor'), child: PageEditor()),
+      ];
+
+  @override
+  List<Pattern> get pathPatterns => ['/advanced/page-editor'];
+}
+
+/// The real [PageEditor], wired up enough to pump.
+Widget buildEditorUnderTest(PageManager manager) {
+  final routerDelegate = BeamerDelegate(
+    locationBuilder: (routeInformation, _) => _EditorLocation(),
+  );
+  return ProviderScope(
+    overrides: [
+      pageManagerProvider.overrideWith((ref) async => manager),
+      // Keep the editor off the database / PLC / alarm stack: BaseScaffold
+      // only needs these to decide between the clock and the alarm banner.
+      databaseProvider.overrideWith((ref) async => null),
+      alarmManProvider
+          .overrideWith((ref) => throw StateError('No AlarmMan in tests')),
+    ],
+    child: BeamerProvider(
+      routerDelegate: routerDelegate,
+      child: MaterialApp.router(
+        routerDelegate: routerDelegate,
+        routeInformationParser: BeamerParser(),
+      ),
+    ),
+  );
+}
+
+/// Per-test setup the editor needs before it will pump.
+void setUpEditorEnvironment() {
+  // The asset canvas constructs SharedPreferencesAsync directly.
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
+  // BaseScaffold renders a NavigationBar from the registry, which asserts on
+  // fewer than two destinations.
+  final registry = RouteRegistry();
+  registry.menuItems.clear();
+  registry
+      .addMenuItem(const MenuItem(label: 'Home', path: '/', icon: Icons.home));
+  registry.addMenuItem(const MenuItem(
+      label: 'Advanced', path: '/advanced', icon: Icons.settings));
+}
+
+/// Pumps the editor at a fixed 1400x1000 with [assets] on the home page.
+Future<FakeEditorPreferences> pumpEditorWith(
+    WidgetTester tester, List<Asset> assets) async {
+  tester.view.physicalSize = const Size(1400, 1000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  final prefs = FakeEditorPreferences();
+  await tester
+      .pumpWidget(buildEditorUnderTest(editorManagerWith(assets, prefs)));
+  await tester.pumpAndSettle();
+  return prefs;
+}
+
+/// A point at relative ([fx], [fy]) within the rendered canvas.
+Offset onCanvas(WidgetTester tester, double fx, double fy) {
+  final r = tester.getRect(find.byType(AssetStack));
+  return Offset(r.left + r.width * fx, r.top + r.height * fy);
+}
+
+/// The canvas's width / height, recovered from the live layout.
+double canvasAspect(WidgetTester tester) {
+  final r = tester.getRect(find.byType(AssetStack));
+  return r.width / r.height;
+}
+
+/// Switches the editor from pan mode into marquee-select mode.
+Future<void> enterSelectMode(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.pan_tool));
+  await tester.pumpAndSettle();
+  expect(find.byIcon(Icons.select_all), findsOneWidget,
+      reason: 'the mode button should now show select mode');
+}
+
+/// Rubber-bands from ([x1], [y1]) to ([x2], [y2]) in canvas-relative units.
+Future<void> marquee(
+    WidgetTester tester, double x1, double y1, double x2, double y2) async {
+  final gesture = await tester.startGesture(onCanvas(tester, x1, y1));
+  await tester.pump();
+  // Two moves: the first crosses the slop, the second lands on the corner.
+  await gesture.moveTo(onCanvas(tester, (x1 + x2) / 2, (y1 + y2) / 2));
+  await tester.pump();
+  await gesture.moveTo(onCanvas(tester, x2, y2));
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+/// Opens the canvas context menu over the asset at relative ([fx], [fy]) and
+/// taps the entry labelled [label].
+Future<void> chooseFromAssetMenu(
+    WidgetTester tester, double fx, double fy, String label) async {
+  await tester.tapAt(onCanvas(tester, fx, fy), buttons: kSecondaryButton);
+  await tester.pumpAndSettle();
+  expect(find.text(label), findsOneWidget,
+      reason: 'the context menu should offer "$label"');
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
+}
+
+/// Presses the editor's undo shortcut. It is keyboard-only, and the editor
+/// picks the modifier from `Platform`, so the test has to match.
+Future<void> pressUndo(WidgetTester tester) async {
+  final modifier = Platform.isMacOS
+      ? LogicalKeyboardKey.metaLeft
+      : LogicalKeyboardKey.controlLeft;
+  await tester.sendKeyDownEvent(modifier);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(modifier);
+  await tester.pumpAndSettle();
+}
+
+/// Saves, then returns the persisted assets of the home page in page order.
+Future<List<Map<String, dynamic>>> saveAndReadBack(
+    WidgetTester tester, FakeEditorPreferences prefs) async {
+  await tester.tap(find.byIcon(Icons.save));
+  await tester.pumpAndSettle();
+
+  // The manager writes the whole page map under a single key; find the entry
+  // that parses as one and contains our page.
+  for (final value in prefs._store.values) {
+    if (value is! String) continue;
+    final decoded = jsonDecode(value);
+    if (decoded is! Map<String, dynamic>) continue;
+    final page = decoded['/'];
+    if (page is Map<String, dynamic> && page['assets'] is List) {
+      return (page['assets'] as List).cast<Map<String, dynamic>>();
+    }
+  }
+  fail('no saved page found in preferences: ${prefs._store.keys}');
+}
+
+/// The `coordinates` block of a persisted asset.
+Map<String, dynamic> coordsOf(Map<String, dynamic> asset) =>
+    asset['coordinates'] as Map<String, dynamic>;
+
+/// The persisted x of each asset, in page order.
+List<double> savedXs(List<Map<String, dynamic>> saved) =>
+    [for (final a in saved) coordsOf(a)['x'] as double];
+
+/// The persisted y of each asset, in page order.
+List<double> savedYs(List<Map<String, dynamic>> saved) =>
+    [for (final a in saved) coordsOf(a)['y'] as double];

--- a/test/pages/page_editor_align_group_test.dart
+++ b/test/pages/page_editor_align_group_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tfc/pages/page_editor.dart';
+
+/// `alignGroup` backs the editor's "Align horizontally / vertically" entries.
+/// It moves every selected asset's centre onto the midpoint between the two
+/// outermost centres, along one axis only.
+///
+/// The axis naming is the easy thing to get backwards: aligning *horizontally*
+/// produces a horizontal row, which means a shared **y**.
+///
+/// `isAlreadyAligned` decides whether the menu entry is enabled, so it has to
+/// agree exactly with "alignGroup would change nothing".
+void main() {
+  List<AssetPlacement> align(List<AssetPlacement> placements, AlignAxis axis) =>
+      alignGroup(placements: placements, axis: axis);
+
+  AssetPlacement at(double x, double y, {double? angle, double size = 0.1}) =>
+      AssetPlacement(x: x, y: y, width: size, height: size, angle: angle);
+
+  group('alignGroup — horizontal', () {
+    test('gives every asset the shared midpoint y', () {
+      final result = align(
+          [at(0.2, 0.2), at(0.5, 0.6), at(0.8, 0.4)], AlignAxis.horizontal);
+
+      // Extremes are 0.2 and 0.6, so the line is 0.4.
+      for (final p in result) {
+        expect(p.y, closeTo(0.4, 1e-12));
+      }
+    });
+
+    test('leaves x alone', () {
+      final result = align(
+          [at(0.2, 0.2), at(0.5, 0.6), at(0.8, 0.4)], AlignAxis.horizontal);
+
+      expect(result.map((p) => p.x), [0.2, 0.5, 0.8]);
+    });
+  });
+
+  group('alignGroup — vertical', () {
+    test('gives every asset the shared midpoint x', () {
+      final result =
+          align([at(0.2, 0.2), at(0.6, 0.5), at(0.4, 0.8)], AlignAxis.vertical);
+
+      for (final p in result) {
+        expect(p.x, closeTo(0.4, 1e-12));
+      }
+    });
+
+    test('leaves y alone', () {
+      final result =
+          align([at(0.2, 0.2), at(0.6, 0.5), at(0.4, 0.8)], AlignAxis.vertical);
+
+      expect(result.map((p) => p.y), [0.2, 0.5, 0.8]);
+    });
+  });
+
+  group('alignGroup — which line', () {
+    test('is the midpoint of the extremes, not the mean', () {
+      // Three assets crowded at the bottom and one at the top. The mean would
+      // be 0.7; a drawing tool puts the line halfway between the outermost
+      // two, so the extremes move symmetrically toward each other.
+      final result = align(
+        [at(0.1, 0.1), at(0.3, 0.9), at(0.5, 0.9), at(0.7, 0.9)],
+        AlignAxis.horizontal,
+      );
+
+      for (final p in result) {
+        expect(p.y, closeTo(0.5, 1e-12));
+      }
+    });
+
+    test('ignores asset sizes — centres are what line up', () {
+      // A big asset next to a small one: the line sits between their centres,
+      // not weighted by how much canvas each covers.
+      final result = align([
+        AssetPlacement(x: 0.3, y: 0.2, width: 0.5, height: 0.4),
+        AssetPlacement(x: 0.7, y: 0.6, width: 0.02, height: 0.02),
+      ], AlignAxis.horizontal);
+
+      for (final p in result) {
+        expect(p.y, closeTo(0.4, 1e-12));
+      }
+    });
+
+    test('is idempotent', () {
+      final once = align([at(0.2, 0.2), at(0.5, 0.7)], AlignAxis.horizontal);
+      final twice = align(once, AlignAxis.horizontal);
+
+      for (var i = 0; i < once.length; i++) {
+        expect(twice[i].y, once[i].y);
+        expect(twice[i].x, once[i].x);
+      }
+    });
+  });
+
+  group('alignGroup — the two axes compose', () {
+    test('aligning both stacks every asset on one point', () {
+      final result = align(
+        align([at(0.2, 0.2), at(0.8, 0.6)], AlignAxis.horizontal),
+        AlignAxis.vertical,
+      );
+
+      for (final p in result) {
+        expect(p.x, closeTo(0.5, 1e-12));
+        expect(p.y, closeTo(0.4, 1e-12));
+      }
+    });
+
+    test('the second align does not disturb the first', () {
+      final horizontal =
+          align([at(0.2, 0.2), at(0.8, 0.6)], AlignAxis.horizontal);
+      final both = align(horizontal, AlignAxis.vertical);
+
+      for (var i = 0; i < both.length; i++) {
+        expect(both[i].y, horizontal[i].y, reason: 'y should survive');
+      }
+    });
+  });
+
+  group('alignGroup — passthrough', () {
+    test('sizes and angles are untouched', () {
+      final result = align([
+        AssetPlacement(x: 0.3, y: 0.2, width: 0.4, height: 0.1, angle: 45),
+        AssetPlacement(x: 0.7, y: 0.6, width: 0.05, height: 0.3),
+      ], AlignAxis.horizontal);
+
+      expect(result[0].width, 0.4);
+      expect(result[0].height, 0.1);
+      expect(result[0].angle, 45);
+      expect(result[1].angle, isNull);
+    });
+
+    test('does not mutate the input', () {
+      final before = [at(0.2, 0.2), at(0.8, 0.6)];
+      align(before, AlignAxis.horizontal);
+
+      expect(before[0].y, 0.2);
+      expect(before[1].y, 0.6);
+    });
+
+    test('an empty selection returns empty', () {
+      expect(align([], AlignAxis.horizontal), isEmpty);
+    });
+
+    test('a single asset is left where it is', () {
+      // Its own centre is the midpoint of the extremes.
+      final result = align([at(0.3, 0.7)], AlignAxis.horizontal);
+      expect(result.single.x, 0.3);
+      expect(result.single.y, 0.7);
+    });
+  });
+
+  group('isAlreadyAligned', () {
+    test('true for a row that already shares a y', () {
+      expect(
+        isAlreadyAligned([at(0.2, 0.5), at(0.8, 0.5)], AlignAxis.horizontal),
+        isTrue,
+      );
+    });
+
+    test('false as soon as one asset is off the line', () {
+      expect(
+        isAlreadyAligned(
+            [at(0.2, 0.5), at(0.5, 0.5), at(0.8, 0.51)], AlignAxis.horizontal),
+        isFalse,
+      );
+    });
+
+    test('checks the axis it was asked about', () {
+      // A row shares a y but not an x.
+      final row = [at(0.2, 0.5), at(0.8, 0.5)];
+      expect(isAlreadyAligned(row, AlignAxis.horizontal), isTrue);
+      expect(isAlreadyAligned(row, AlignAxis.vertical), isFalse);
+    });
+
+    test('true for fewer than two assets — nothing to line up', () {
+      expect(isAlreadyAligned([], AlignAxis.horizontal), isTrue);
+      expect(isAlreadyAligned([at(0.3, 0.7)], AlignAxis.horizontal), isTrue);
+    });
+
+    test('true for whatever alignGroup just produced', () {
+      // alignGroup writes one identical value, so exact equality holds and the
+      // menu entry disables itself after a successful align.
+      for (final axis in AlignAxis.values) {
+        final aligned = align([at(0.2, 0.2), at(0.5, 0.9), at(0.8, 0.4)], axis);
+        expect(isAlreadyAligned(aligned, axis), isTrue, reason: '$axis');
+      }
+    });
+
+    test('agrees with alignGroup being a no-op', () {
+      // The predicate exists to disable the menu entry, so it must be exactly
+      // the cases where aligning would change nothing.
+      final cases = [
+        [at(0.2, 0.5), at(0.8, 0.5)],
+        [at(0.2, 0.5), at(0.8, 0.6)],
+        [at(0.5, 0.2), at(0.5, 0.8)],
+        [at(0.3, 0.7)],
+        <AssetPlacement>[],
+      ];
+      for (final placements in cases) {
+        for (final axis in AlignAxis.values) {
+          final result = align(placements, axis);
+          final unchanged = List.generate(
+            placements.length,
+            (i) =>
+                result[i].x == placements[i].x &&
+                result[i].y == placements[i].y,
+          ).every((same) => same);
+
+          expect(isAlreadyAligned(placements, axis), unchanged,
+              reason: 'mismatch for $axis on '
+                  '${placements.map((p) => '(${p.x},${p.y})').join(' ')}');
+        }
+      }
+    });
+  });
+}

--- a/test/widgets/page_editor_align_selection_test.dart
+++ b/test/widgets/page_editor_align_selection_test.dart
@@ -1,0 +1,157 @@
+/// End-to-end cover for aligning a multi-selection in the page editor.
+///
+/// The maths lives in `alignGroup` and is unit-tested in
+/// test/pages/page_editor_align_group_test.dart. This drives the real editor
+/// instead: marquee-select scattered boxes, right-click, pick the entry, then
+/// read the saved JSON back.
+///
+/// The two things only an end-to-end test can catch are the axis wiring —
+/// "horizontally" must produce a row, i.e. a shared y — and the enabled state
+/// of the entries, which is what keeps a no-op off the undo history.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/page_editor_harness.dart';
+
+/// Whether the context menu entry labelled [label] is tappable.
+bool _menuEntryEnabled(WidgetTester tester, String label) {
+  final tile = tester.widget<ListTile>(find.ancestor(
+    of: find.text(label),
+    matching: find.byType(ListTile),
+  ));
+  return tile.enabled;
+}
+
+void main() {
+  setUp(setUpEditorEnvironment);
+
+  /// Three boxes at scattered positions: no two share an x or a y.
+  Future<FakeEditorPreferences> pumpScattered(WidgetTester tester) =>
+      pumpEditorWith(tester,
+          [editorBox(0.2, 0.3), editorBox(0.5, 0.7), editorBox(0.8, 0.5)]);
+
+  /// Marquee-selects all three.
+  Future<void> selectAll(WidgetTester tester) async {
+    await enterSelectMode(tester);
+    await marquee(tester, 0.1, 0.15, 0.9, 0.85);
+  }
+
+  /// Opens the menu over the asset at ([fx], [fy]) without choosing anything.
+  Future<void> openMenu(WidgetTester tester, double fx, double fy) async {
+    await tester.tapAt(onCanvas(tester, fx, fy), buttons: kSecondaryButton);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('aligns a selection horizontally into a row', (tester) async {
+    final prefs = await pumpScattered(tester);
+    await selectAll(tester);
+
+    // The label proves all three are selected.
+    await chooseFromAssetMenu(tester, 0.5, 0.7, 'Align 3 assets horizontally');
+
+    final saved = await saveAndReadBack(tester, prefs);
+
+    // A row: one shared y, at the midpoint of the outermost centres
+    // (0.3 and 0.7).
+    for (final y in savedYs(saved)) {
+      expect(y, closeTo(0.5, 1e-9));
+    }
+    // x untouched — this is the axis assertion that catches a swap.
+    expect(savedXs(saved),
+        [closeTo(0.2, 1e-9), closeTo(0.5, 1e-9), closeTo(0.8, 1e-9)]);
+  });
+
+  testWidgets('aligns a selection vertically into a column', (tester) async {
+    final prefs = await pumpScattered(tester);
+    await selectAll(tester);
+
+    await chooseFromAssetMenu(tester, 0.5, 0.7, 'Align 3 assets vertically');
+
+    final saved = await saveAndReadBack(tester, prefs);
+
+    // A column: one shared x, midway between 0.2 and 0.8.
+    for (final x in savedXs(saved)) {
+      expect(x, closeTo(0.5, 1e-9));
+    }
+    expect(savedYs(saved),
+        [closeTo(0.3, 1e-9), closeTo(0.7, 1e-9), closeTo(0.5, 1e-9)]);
+  });
+
+  testWidgets('angles survive an align', (tester) async {
+    // Aligning moves assets; it must not quietly straighten them.
+    final prefs = await pumpEditorWith(tester, [
+      editorBox(0.3, 0.3, angle: 45),
+      editorBox(0.7, 0.7),
+    ]);
+    await enterSelectMode(tester);
+    await marquee(tester, 0.15, 0.15, 0.85, 0.85);
+
+    await chooseFromAssetMenu(tester, 0.7, 0.7, 'Align 2 assets horizontally');
+
+    final saved = await saveAndReadBack(tester, prefs);
+    expect(coordsOf(saved[0])['angle'], 45);
+    expect(coordsOf(saved[1])['angle'], isNull);
+  });
+
+  testWidgets('both aligns together stack the selection on one point',
+      (tester) async {
+    final prefs = await pumpScattered(tester);
+    await selectAll(tester);
+
+    await chooseFromAssetMenu(tester, 0.5, 0.7, 'Align 3 assets horizontally');
+    // After the first align the selection still holds, but every asset now
+    // shares a y — so the boxes overlap and the click point has to be one
+    // that is still on an asset.
+    await chooseFromAssetMenu(tester, 0.5, 0.5, 'Align 3 assets vertically');
+
+    final saved = await saveAndReadBack(tester, prefs);
+    for (final asset in saved) {
+      expect(coordsOf(asset)['x'] as double, closeTo(0.5, 1e-9));
+      expect(coordsOf(asset)['y'] as double, closeTo(0.5, 1e-9));
+    }
+  });
+
+  testWidgets('undo reverts an align in one step', (tester) async {
+    final prefs = await pumpScattered(tester);
+    await selectAll(tester);
+
+    await chooseFromAssetMenu(tester, 0.5, 0.7, 'Align 3 assets horizontally');
+    await pressUndo(tester);
+
+    final saved = await saveAndReadBack(tester, prefs);
+    expect(savedYs(saved),
+        [closeTo(0.3, 1e-9), closeTo(0.7, 1e-9), closeTo(0.5, 1e-9)]);
+  });
+
+  testWidgets('an already-aligned selection disables the entry',
+      (tester) async {
+    // A row already shares a y, so aligning horizontally would do nothing and
+    // must not be offered — otherwise it burns an undo step. Aligning
+    // vertically is still real work, which proves the check is per axis.
+    await pumpEditorWith(tester,
+        [editorBox(0.3, 0.5), editorBox(0.5, 0.5), editorBox(0.7, 0.5)]);
+    await enterSelectMode(tester);
+    await marquee(tester, 0.15, 0.3, 0.85, 0.7);
+
+    await openMenu(tester, 0.5, 0.5);
+
+    expect(_menuEntryEnabled(tester, 'Align 3 assets horizontally'), isFalse,
+        reason: 'the row already shares a y');
+    expect(_menuEntryEnabled(tester, 'Align 3 assets vertically'), isTrue,
+        reason: 'the row does not share an x');
+  });
+
+  testWidgets('a single asset cannot be aligned', (tester) async {
+    // Outside select mode the menu acts on one asset, which is already its own
+    // group centre — there is nothing to line up.
+    await pumpScattered(tester);
+
+    await openMenu(tester, 0.2, 0.3);
+
+    expect(_menuEntryEnabled(tester, 'Align horizontally'), isFalse);
+    expect(_menuEntryEnabled(tester, 'Align vertically'), isFalse);
+  });
+}

--- a/test/widgets/page_editor_rotate_selection_test.dart
+++ b/test/widgets/page_editor_rotate_selection_test.dart
@@ -11,271 +11,48 @@
 /// pick "Rotate 3 assets 90° clockwise", then read the saved JSON back.
 library;
 
-import 'dart:convert';
-import 'dart:io' show Platform;
-
-import 'package:beamer/beamer.dart';
-import 'package:flutter/gestures.dart' show kSecondaryButton;
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show LogicalKeyboardKey;
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
-import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
-import 'package:tfc_dart/core/preferences.dart';
 
-import 'package:tfc/models/menu_item.dart';
-import 'package:tfc/page_creator/assets/common.dart';
-import 'package:tfc/page_creator/assets/drawn_box.dart';
-import 'package:tfc/page_creator/page.dart';
-import 'package:tfc/pages/page_editor.dart';
-import 'package:tfc/pages/page_view.dart';
-import 'package:tfc/providers/alarm.dart';
-import 'package:tfc/providers/database.dart';
-import 'package:tfc/providers/page_manager.dart';
-import 'package:tfc/route_registry.dart';
-
-/// Minimal in-memory [PreferencesApi] so the editor can load and save.
-/// Doubles as the read-back channel: whatever the save button writes here is
-/// what the operator would get on reload.
-class _FakePreferences implements PreferencesApi {
-  final Map<String, Object> _store = {};
-
-  @override
-  Future<String?> getString(String key) async => _store[key] as String?;
-  @override
-  Future<void> setString(String key, String value) async => _store[key] = value;
-  @override
-  Future<Set<String>> getKeys({Set<String>? allowList}) async =>
-      _store.keys.toSet();
-  @override
-  Future<Map<String, Object?>> getAll({Set<String>? allowList}) async =>
-      Map.from(_store);
-  @override
-  Future<bool?> getBool(String key) async => _store[key] as bool?;
-  @override
-  Future<int?> getInt(String key) async => _store[key] as int?;
-  @override
-  Future<double?> getDouble(String key) async => _store[key] as double?;
-  @override
-  Future<List<String>?> getStringList(String key) async =>
-      _store[key] as List<String>?;
-  @override
-  Future<bool> containsKey(String key) async => _store.containsKey(key);
-  @override
-  Future<void> setBool(String key, bool value) async => _store[key] = value;
-  @override
-  Future<void> setInt(String key, int value) async => _store[key] = value;
-  @override
-  Future<void> setDouble(String key, double value) async => _store[key] = value;
-  @override
-  Future<void> setStringList(String key, List<String> value) async =>
-      _store[key] = value;
-  @override
-  Future<void> remove(String key) async => _store.remove(key);
-  @override
-  Future<void> clear({Set<String>? allowList}) async {
-    if (allowList == null) {
-      _store.clear();
-    } else {
-      _store.removeWhere((k, _) => allowList.contains(k));
-    }
-  }
-}
-
-/// A box at ([x], [y]). Deliberately non-square so a quarter turn is visible
-/// in the persisted extents as well as the coordinates.
-DrawnBoxConfig _box(double x, double y, {double? angle}) {
-  return DrawnBoxConfig.preview()
-    ..coordinates = Coordinates(x: x, y: y, angle: angle)
-    ..size = const RelativeSize(width: 0.12, height: 0.06);
-}
-
-PageManager _managerWith(List<Asset> assets, _FakePreferences prefs) {
-  return PageManager(
-    prefs: prefs,
-    pages: {
-      '/': AssetPage(
-        menuItem: const MenuItem(label: 'Home', path: '/', icon: Icons.home),
-        assets: assets,
-        mirroringDisabled: true,
-        navigationPriority: 0,
-      ),
-    },
-  );
-}
-
-/// The editor lives inside `BaseScaffold`, which reads the current Beamer
-/// location during build, so it needs a router above it.
-class _EditorLocation extends BeamLocation<BeamState> {
-  _EditorLocation()
-      : super(RouteInformation(uri: Uri.parse('/advanced/page-editor')));
-
-  @override
-  List<BeamPage> buildPages(BuildContext context, BeamState state) => const [
-        BeamPage(key: ValueKey('page-editor'), child: PageEditor()),
-      ];
-
-  @override
-  List<Pattern> get pathPatterns => ['/advanced/page-editor'];
-}
-
-Widget _buildEditor(PageManager manager) {
-  final routerDelegate = BeamerDelegate(
-    locationBuilder: (routeInformation, _) => _EditorLocation(),
-  );
-  return ProviderScope(
-    overrides: [
-      pageManagerProvider.overrideWith((ref) async => manager),
-      // Keep the editor off the database / PLC / alarm stack: BaseScaffold
-      // only needs these to decide between the clock and the alarm banner.
-      databaseProvider.overrideWith((ref) async => null),
-      alarmManProvider
-          .overrideWith((ref) => throw StateError('No AlarmMan in tests')),
-    ],
-    child: BeamerProvider(
-      routerDelegate: routerDelegate,
-      child: MaterialApp.router(
-        routerDelegate: routerDelegate,
-        routeInformationParser: BeamerParser(),
-      ),
-    ),
-  );
-}
-
-/// A point at relative ([fx], [fy]) within the rendered canvas.
-Offset _onCanvas(WidgetTester tester, double fx, double fy) {
-  final r = tester.getRect(find.byType(AssetStack));
-  return Offset(r.left + r.width * fx, r.top + r.height * fy);
-}
-
-/// The canvas's width / height — the aspect ratio the rotation has to correct
-/// for, recovered from the live layout rather than assumed.
-double _canvasAspect(WidgetTester tester) {
-  final r = tester.getRect(find.byType(AssetStack));
-  return r.width / r.height;
-}
-
-/// Switches the editor from pan mode into marquee-select mode.
-Future<void> _enterSelectMode(WidgetTester tester) async {
-  await tester.tap(find.byIcon(Icons.pan_tool));
-  await tester.pumpAndSettle();
-  expect(find.byIcon(Icons.select_all), findsOneWidget,
-      reason: 'the mode button should now show select mode');
-}
-
-/// Rubber-bands from ([x1], [y1]) to ([x2], [y2]) in canvas-relative units.
-Future<void> _marquee(
-    WidgetTester tester, double x1, double y1, double x2, double y2) async {
-  final gesture = await tester.startGesture(_onCanvas(tester, x1, y1));
-  await tester.pump();
-  // Two moves: the first crosses the slop, the second lands on the corner.
-  await gesture.moveTo(_onCanvas(tester, (x1 + x2) / 2, (y1 + y2) / 2));
-  await tester.pump();
-  await gesture.moveTo(_onCanvas(tester, x2, y2));
-  await tester.pump();
-  await gesture.up();
-  await tester.pumpAndSettle();
-}
-
-/// Presses the editor's undo shortcut. It is keyboard-only, and the editor
-/// picks the modifier from `Platform`, so the test has to match.
-Future<void> _pressUndo(WidgetTester tester) async {
-  final modifier = Platform.isMacOS
-      ? LogicalKeyboardKey.metaLeft
-      : LogicalKeyboardKey.controlLeft;
-  await tester.sendKeyDownEvent(modifier);
-  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
-  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
-  await tester.sendKeyUpEvent(modifier);
-  await tester.pumpAndSettle();
-}
-
-/// Saves, then returns the persisted assets of the home page in page order.
-Future<List<Map<String, dynamic>>> _saveAndReadBack(
-    WidgetTester tester, _FakePreferences prefs) async {
-  await tester.tap(find.byIcon(Icons.save));
-  await tester.pumpAndSettle();
-
-  // The manager writes the whole page map under a single key; find the entry
-  // that parses as one and contains our page.
-  for (final value in prefs._store.values) {
-    if (value is! String) continue;
-    final decoded = jsonDecode(value);
-    if (decoded is! Map<String, dynamic>) continue;
-    final page = decoded['/'];
-    if (page is Map<String, dynamic> && page['assets'] is List) {
-      return (page['assets'] as List).cast<Map<String, dynamic>>();
-    }
-  }
-  fail('no saved page found in preferences: ${prefs._store.keys}');
-}
-
-Map<String, dynamic> _coords(Map<String, dynamic> asset) =>
-    asset['coordinates'] as Map<String, dynamic>;
+import '../helpers/page_editor_harness.dart';
 
 void main() {
-  setUp(() {
-    // The asset canvas constructs SharedPreferencesAsync directly.
-    SharedPreferencesAsyncPlatform.instance =
-        InMemorySharedPreferencesAsync.empty();
-
-    // BaseScaffold renders a NavigationBar from the registry, which asserts on
-    // fewer than two destinations.
-    final registry = RouteRegistry();
-    registry.menuItems.clear();
-    registry.addMenuItem(
-        const MenuItem(label: 'Home', path: '/', icon: Icons.home));
-    registry.addMenuItem(const MenuItem(
-        label: 'Advanced', path: '/advanced', icon: Icons.settings));
-  });
+  setUp(setUpEditorEnvironment);
 
   /// A row of three boxes across the middle of the canvas.
-  Future<_FakePreferences> pumpRow(WidgetTester tester) async {
-    tester.view.physicalSize = const Size(1400, 1000);
-    tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.reset);
+  Future<FakeEditorPreferences> pumpRow(WidgetTester tester) => pumpEditorWith(
+      tester, [editorBox(0.3, 0.5), editorBox(0.5, 0.5), editorBox(0.7, 0.5)]);
 
-    final prefs = _FakePreferences();
-    await tester.pumpWidget(_buildEditor(_managerWith(
-      [_box(0.3, 0.5), _box(0.5, 0.5), _box(0.7, 0.5)],
-      prefs,
-    )));
-    await tester.pumpAndSettle();
-    expect(find.byType(DrawnBox), findsNWidgets(3));
-    return prefs;
+  /// Marquee-selects the whole row.
+  Future<void> selectRow(WidgetTester tester) async {
+    await enterSelectMode(tester);
+    await marquee(tester, 0.15, 0.3, 0.85, 0.7);
   }
 
   testWidgets('rotates a marquee selection as a group', (tester) async {
     final prefs = await pumpRow(tester);
-    final aspect = _canvasAspect(tester);
+    final aspect = canvasAspect(tester);
     // The spacing assertion below is only meaningful on a non-square canvas —
     // on a square one it would pass with the aspect handling ripped out.
     expect(aspect, greaterThan(1.5),
         reason: 'the editor canvas should be wide (it renders 16:9)');
 
-    await _enterSelectMode(tester);
-    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
+    await selectRow(tester);
 
-    // Right-click the middle box. The label proves all three are selected —
-    // if the marquee had missed, this would read "Rotate 90° clockwise".
-    await tester.tapAt(_onCanvas(tester, 0.5, 0.5), buttons: kSecondaryButton);
-    await tester.pumpAndSettle();
-    expect(find.text('Rotate 3 assets 90° clockwise'), findsOneWidget);
+    // The label proves all three are selected — if the marquee had missed,
+    // it would read "Rotate 90° clockwise".
+    await chooseFromAssetMenu(
+        tester, 0.5, 0.5, 'Rotate 3 assets 90° clockwise');
 
-    await tester.tap(find.text('Rotate 3 assets 90° clockwise'));
-    await tester.pumpAndSettle();
-
-    final saved = await _saveAndReadBack(tester, prefs);
+    final saved = await saveAndReadBack(tester, prefs);
     expect(saved, hasLength(3));
 
     // The row is now a column through the group's centre.
-    for (final asset in saved) {
-      expect(_coords(asset)['x'] as double, closeTo(0.5, 1e-9));
+    for (final x in savedXs(saved)) {
+      expect(x, closeTo(0.5, 1e-9));
     }
 
     // Clockwise: the leftmost box is now the topmost.
-    final ys = [for (final a in saved) _coords(a)['y'] as double];
+    final ys = savedYs(saved);
     expect(ys[0], lessThan(ys[1]));
     expect(ys[1], lessThan(ys[2]));
 
@@ -287,64 +64,47 @@ void main() {
 
     // ...and every box spun, not just orbited.
     for (final asset in saved) {
-      expect(_coords(asset)['angle'], 90);
+      expect(coordsOf(asset)['angle'], 90);
     }
   });
 
   testWidgets('rotating back restores the original layout', (tester) async {
     final prefs = await pumpRow(tester);
+    await selectRow(tester);
 
-    await _enterSelectMode(tester);
-    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
-
-    Future<void> rotate(String label) async {
-      await tester.tapAt(_onCanvas(tester, 0.5, 0.5),
-          buttons: kSecondaryButton);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(label));
-      await tester.pumpAndSettle();
-    }
-
-    await rotate('Rotate 3 assets 90° clockwise');
+    await chooseFromAssetMenu(
+        tester, 0.5, 0.5, 'Rotate 3 assets 90° clockwise');
     // The selection survives the rotation, so the second turn hits the same
     // three assets — worth asserting, since losing it would silently make the
     // menu act on one box.
-    await rotate('Rotate 3 assets 90° counter-clockwise');
+    await chooseFromAssetMenu(
+        tester, 0.5, 0.5, 'Rotate 3 assets 90° counter-clockwise');
 
-    final saved = await _saveAndReadBack(tester, prefs);
-    final xs = [for (final a in saved) _coords(a)['x'] as double];
-    final ys = [for (final a in saved) _coords(a)['y'] as double];
-
-    expect(xs[0], closeTo(0.3, 1e-9));
-    expect(xs[1], closeTo(0.5, 1e-9));
-    expect(xs[2], closeTo(0.7, 1e-9));
-    for (final y in ys) {
+    final saved = await saveAndReadBack(tester, prefs);
+    expect(savedXs(saved),
+        [closeTo(0.3, 1e-9), closeTo(0.5, 1e-9), closeTo(0.7, 1e-9)]);
+    for (final y in savedYs(saved)) {
       expect(y, closeTo(0.5, 1e-9));
     }
     // Back to "never rotated", so mirrored pages behave as they did before.
     for (final asset in saved) {
-      expect(_coords(asset)['angle'], isNull);
+      expect(coordsOf(asset)['angle'], isNull);
     }
   });
 
   testWidgets('undo reverts a group rotation in one step', (tester) async {
     final prefs = await pumpRow(tester);
+    await selectRow(tester);
 
-    await _enterSelectMode(tester);
-    await _marquee(tester, 0.15, 0.3, 0.85, 0.7);
+    await chooseFromAssetMenu(
+        tester, 0.5, 0.5, 'Rotate 3 assets 90° clockwise');
+    await pressUndo(tester);
 
-    await tester.tapAt(_onCanvas(tester, 0.5, 0.5), buttons: kSecondaryButton);
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Rotate 3 assets 90° clockwise'));
-    await tester.pumpAndSettle();
-
-    await _pressUndo(tester);
-
-    final saved = await _saveAndReadBack(tester, prefs);
-    expect([for (final a in saved) _coords(a)['x'] as double],
+    final saved = await saveAndReadBack(tester, prefs);
+    expect(savedXs(saved),
         [closeTo(0.3, 1e-9), closeTo(0.5, 1e-9), closeTo(0.7, 1e-9)]);
     for (final asset in saved) {
-      expect(_coords(asset)['angle'], isNull);
+      expect(coordsOf(asset)['angle'], isNull);
     }
   });
 
@@ -353,21 +113,15 @@ void main() {
     // asset under the cursor — and a single asset spins in place.
     final prefs = await pumpRow(tester);
 
-    await tester.tapAt(_onCanvas(tester, 0.3, 0.5), buttons: kSecondaryButton);
-    await tester.pumpAndSettle();
-    expect(find.text('Rotate 90° clockwise'), findsOneWidget,
-        reason: 'no selection, so the label should be singular');
+    await chooseFromAssetMenu(tester, 0.3, 0.5, 'Rotate 90° clockwise');
 
-    await tester.tap(find.text('Rotate 90° clockwise'));
-    await tester.pumpAndSettle();
-
-    final saved = await _saveAndReadBack(tester, prefs);
-    expect(_coords(saved[0])['angle'], 90);
-    expect(_coords(saved[0])['x'] as double, closeTo(0.3, 1e-9));
-    expect(_coords(saved[0])['y'] as double, closeTo(0.5, 1e-9));
+    final saved = await saveAndReadBack(tester, prefs);
+    expect(coordsOf(saved[0])['angle'], 90);
+    expect(savedXs(saved)[0], closeTo(0.3, 1e-9));
+    expect(savedYs(saved)[0], closeTo(0.5, 1e-9));
 
     // The other two are untouched.
-    expect(_coords(saved[1])['angle'], isNull);
-    expect(_coords(saved[2])['angle'], isNull);
+    expect(coordsOf(saved[1])['angle'], isNull);
+    expect(coordsOf(saved[2])['angle'], isNull);
   });
 }


### PR DESCRIPTION
Follow-up to #138. Right-clicking a selection now offers **Align N assets horizontally** and **Align N assets vertically**, putting every selected asset's centre on one line.

```
before:                 after "align horizontally":

     [B]                    [A] [B] [C]
  [A]     [C]
```

"Horizontally" means the assets end up in a horizontal *row* — a shared `y`, `x` untouched — and vertically is the mirror of that.

## Decisions worth a look

- **The line is the midpoint of the extremes, not the mean.** With three assets crowded at the bottom and one at the top, the mean would drag the line down to them; the midpoint moves the two outermost assets symmetrically toward each other, which is what a drawing tool does.
- **Centres line up, not edges.** Assets of differing sizes end up with their middles on one line and their edges ragged. This also makes align the one selection action that needs **no aspect-ratio correction** — it writes a constant into a single normalized axis and leaves the other alone, so unlike the rotation there's no cross-axis maths and no `BoxConstraints` to thread through.
- **The entries disable themselves on a no-op**, mirroring how "Send to back" avoids burning an undo step. The check is per axis, so a row offers "align vertically" but greys out "align horizontally". A single asset is its own group centre, so neither entry is offered for one.

## Refactor included

The end-to-end harness the rotation tests grew (Beamer location, route registry, fake preferences, marquee/menu/undo drivers, save-and-read-back) is extracted to `test/helpers/page_editor_harness.dart` so the align tests reuse it instead of copying ~200 lines. That's most of the deletions in the diff. `_rotateAssets` moves onto the same `_placements` / `_applyPlacements` helpers the align path uses — behaviour unchanged, and its existing tests still pass untouched in substance.

## Testing

- **19 unit tests** (`test/pages/page_editor_align_group_test.dart`) — both axes, which line gets picked, idempotence, composing the two aligns, size/angle passthrough, and `isAlreadyAligned` agreeing exactly with "aligning would change nothing".
- **7 end-to-end tests** (`test/widgets/page_editor_align_selection_test.dart`) — marquee-select scattered boxes, right-click, align, then read the **saved JSON** back. Covers the axis wiring, angles surviving, undo, and both disabled-state cases.
- **Mutation-checked**: swapping the two axes fails 3 tests; always-enabling the entries fails 2.
- Full suite green: **2284 passed**, 6 pre-existing skips. No new analyzer issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)