### PR TITLE
feat(windows): always write a log, and capture crashes into it

### DIFF
--- a/centroid-hmi/windows/runner/CMakeLists.txt
+++ b/centroid-hmi/windows/runner/CMakeLists.txt
@@ -7,8 +7,10 @@ project(runner LANGUAGES CXX)
 #
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
+  "crash_handler.cpp"
   "flutter_window.cpp"
   "gpu_watchdog.cpp"
+  "log_rotation.cpp"
   "main.cpp"
   "utils.cpp"
   "win32_window.cpp"
@@ -38,6 +40,9 @@ target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
 # WTSRegisterSessionNotification — the GPU watchdog uses RDP session changes as
 # a hint that the display adapter (and with it the D3D device) was swapped.
 target_link_libraries(${BINARY_NAME} PRIVATE "wtsapi32.lib")
+# MiniDumpWriteDump — linked rather than LoadLibrary'd, so the crash handler
+# needs no loader activity at the moment it runs.
+target_link_libraries(${BINARY_NAME} PRIVATE "dbghelp.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/centroid-hmi/windows/runner/crash_handler.cpp
+++ b/centroid-hmi/windows/runner/crash_handler.cpp
@@ -1,0 +1,208 @@
+#include "crash_handler.h"
+
+#include <windows.h>
+// dbghelp.h must follow windows.h.
+#include <dbghelp.h>
+// _CrtSetReportMode / _CrtSetReportFile, used in the debug block below.
+#include <crtdbg.h>
+
+#include <csignal>   // signal, SIGABRT
+#include <cstdint>   // uintptr_t, in the invalid-parameter handler signature
+#include <cstdio>    // fputs, fflush, _snprintf_s
+#include <cstdlib>   // _set_abort_behavior, _set_purecall_handler
+#include <exception> // set_terminate, current_exception, rethrow_exception
+#include <typeinfo>  // typeid, to name the exception that killed us
+
+namespace tfc {
+namespace {
+
+// Where minidumps go. Captured at install time because the handlers cannot
+// take arguments and must not allocate.
+char g_dump_dir[MAX_PATH] = {0};
+
+// A crash inside a crash handler must not recurse forever. InterlockedExchange
+// rather than a plain bool: two threads can fault simultaneously.
+LONG g_handling = 0;
+
+bool EnterHandler() {
+  return ::InterlockedExchange(&g_handling, 1) == 0;
+}
+
+// Writes straight to stderr, which the runner has redirected to the log file.
+// Deliberately avoids std::string and iostreams: this runs after things like
+// bad_alloc and stack corruption, where allocation may be exactly what failed.
+void WriteRecord(const char* line) {
+  std::fputs(line, stderr);
+  std::fputs("\n", stderr);
+  std::fflush(stderr);
+  // Also visible to a debugger or DebugView when no log file is configured.
+  ::OutputDebugStringA(line);
+  ::OutputDebugStringA("\n");
+}
+
+void FormatTimestamp(char* out, size_t out_len) {
+  SYSTEMTIME st;
+  ::GetSystemTime(&st);
+  _snprintf_s(out, out_len, _TRUNCATE, "%04u%02u%02u-%02u%02u%02u", st.wYear,
+              st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+}
+
+// Writes a minidump and reports where it went. |pointers| may be null, which
+// still yields usable thread stacks.
+void WriteMinidump(EXCEPTION_POINTERS* pointers, const char* timestamp) {
+  if (g_dump_dir[0] == '\0') {
+    WriteRecord("[crash] no dump directory configured — minidump skipped");
+    return;
+  }
+
+  char path[MAX_PATH];
+  _snprintf_s(path, sizeof(path), _TRUNCATE, "%s\\hmi-crash-%s-%lu.dmp",
+              g_dump_dir, timestamp, ::GetCurrentProcessId());
+
+  HANDLE file = ::CreateFileA(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                              FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file == INVALID_HANDLE_VALUE) {
+    char line[MAX_PATH + 64];
+    _snprintf_s(line, sizeof(line), _TRUNCATE,
+                "[crash] could not create minidump %s (error %lu)", path,
+                ::GetLastError());
+    WriteRecord(line);
+    return;
+  }
+
+  MINIDUMP_EXCEPTION_INFORMATION info;
+  info.ThreadId = ::GetCurrentThreadId();
+  info.ExceptionPointers = pointers;
+  info.ClientPointers = FALSE;
+
+  // Normal + thread info + handles keeps the dump small enough to copy off a
+  // rig while still giving every thread's stack.
+  const MINIDUMP_TYPE type = static_cast<MINIDUMP_TYPE>(
+      MiniDumpNormal | MiniDumpWithThreadInfo | MiniDumpWithHandleData);
+
+  BOOL ok = ::MiniDumpWriteDump(::GetCurrentProcess(), ::GetCurrentProcessId(),
+                                file, type, pointers ? &info : nullptr, nullptr,
+                                nullptr);
+  ::CloseHandle(file);
+
+  char line[MAX_PATH + 64];
+  if (ok) {
+    _snprintf_s(line, sizeof(line), _TRUNCATE, "[crash] minidump written: %s",
+                path);
+  } else {
+    _snprintf_s(line, sizeof(line), _TRUNCATE,
+                "[crash] MiniDumpWriteDump failed (error %lu)",
+                ::GetLastError());
+  }
+  WriteRecord(line);
+}
+
+// Common tail: record what happened, dump, and end the process. Does not
+// return. Uses TerminateProcess rather than abort() so we cannot re-enter the
+// SIGABRT handler, and so no second dialog appears.
+[[noreturn]] void ReportAndDie(const char* kind, const char* detail,
+                               EXCEPTION_POINTERS* pointers, UINT exit_code) {
+  if (EnterHandler()) {
+    char timestamp[32];
+    FormatTimestamp(timestamp, sizeof(timestamp));
+
+    char line[1024];
+    _snprintf_s(line, sizeof(line), _TRUNCATE,
+                "[crash] %s  thread=%lu  time=%s  detail=%s", kind,
+                ::GetCurrentThreadId(), timestamp,
+                detail != nullptr ? detail : "(none)");
+    WriteRecord(line);
+
+    WriteMinidump(pointers, timestamp);
+  }
+  ::TerminateProcess(::GetCurrentProcess(), exit_code);
+  // TerminateProcess does not return, but the compiler wants an end here.
+  ::ExitProcess(exit_code);
+}
+
+LONG WINAPI SehFilter(EXCEPTION_POINTERS* pointers) {
+  char detail[128] = "(no record)";
+  if (pointers != nullptr && pointers->ExceptionRecord != nullptr) {
+    _snprintf_s(detail, sizeof(detail), _TRUNCATE,
+                "code=0x%08lX address=0x%p",
+                pointers->ExceptionRecord->ExceptionCode,
+                pointers->ExceptionRecord->ExceptionAddress);
+  }
+  ReportAndDie("structured exception", detail, pointers, 1);
+}
+
+void TerminateHandler() {
+  // Recovering what() is the whole point: this is the path an exception
+  // escaping a noexcept function takes, and without this the log says nothing
+  // beyond "abort() has been called".
+  const char* detail = "no active exception (explicit terminate, or an "
+                       "exception escaping a noexcept function)";
+  char buffer[512];
+
+  if (std::exception_ptr active = std::current_exception()) {
+    try {
+      std::rethrow_exception(active);
+    } catch (const std::exception& e) {
+      _snprintf_s(buffer, sizeof(buffer), _TRUNCATE, "uncaught %s: %s",
+                  typeid(e).name(), e.what());
+      detail = buffer;
+    } catch (...) {
+      detail = "uncaught exception not derived from std::exception";
+    }
+  }
+
+  ReportAndDie("std::terminate", detail, nullptr, 3);
+}
+
+void SignalHandler(int signal_number) {
+  const char* kind = signal_number == SIGABRT ? "abort()" : "signal";
+  char detail[64];
+  _snprintf_s(detail, sizeof(detail), _TRUNCATE, "signal=%d", signal_number);
+  ReportAndDie(kind, detail, nullptr, 3);
+}
+
+void InvalidParameterHandler(const wchar_t* expression, const wchar_t* function,
+                             const wchar_t* file, unsigned int line,
+                             uintptr_t /*reserved*/) {
+  // The CRT's default for this is to call abort() with no explanation at all.
+  char detail[768];
+  _snprintf_s(detail, sizeof(detail), _TRUNCATE,
+              "expression=%ls function=%ls file=%ls line=%u",
+              expression != nullptr ? expression : L"(null)",
+              function != nullptr ? function : L"(null)",
+              file != nullptr ? file : L"(null)", line);
+  ReportAndDie("CRT invalid parameter", detail, nullptr, 3);
+}
+
+void PureCallHandler() {
+  ReportAndDie("pure virtual call", nullptr, nullptr, 3);
+}
+
+}  // namespace
+
+void InstallCrashHandlers(const std::string& dump_dir) {
+  _snprintf_s(g_dump_dir, sizeof(g_dump_dir), _TRUNCATE, "%s",
+              dump_dir.c_str());
+
+  ::SetUnhandledExceptionFilter(SehFilter);
+  std::set_terminate(TerminateHandler);
+  std::signal(SIGABRT, SignalHandler);
+  _set_invalid_parameter_handler(InvalidParameterHandler);
+  _set_purecall_handler(PureCallHandler);
+
+  // Route SIGABRT to our handler rather than the CRT's message box. WER
+  // reporting is dropped too: we write our own minidump, and a kiosk must not
+  // sit on a modal dialog waiting for a click that will never come.
+  _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+
+#ifdef _DEBUG
+  // Debug-CRT assertions default to a dialog; send them to stderr instead so
+  // they reach the log like everything else.
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+#endif
+}
+
+}  // namespace tfc

--- a/centroid-hmi/windows/runner/crash_handler.h
+++ b/centroid-hmi/windows/runner/crash_handler.h
@@ -1,0 +1,35 @@
+#ifndef RUNNER_CRASH_HANDLER_H_
+#define RUNNER_CRASH_HANDLER_H_
+
+#include <string>
+
+// Process-wide crash capture.
+//
+// Without this, the ways this app can die produce nothing at all in the log:
+//
+//   * abort()                     — CRT prints a message box, if anything
+//   * uncaught C++ exception, or  — std::terminate, then abort
+//     one escaping a noexcept fn
+//   * access violation etc.       — process vanishes
+//   * CRT invalid parameter       — silently calls abort
+//   * pure virtual call           — silently calls abort
+//
+// Each handler installed here writes a one-line record to stderr (which the
+// runner redirects to the log file) and a minidump next to the log, then ends
+// the process deterministically. The record names the failure kind; for an
+// uncaught exception it also recovers the exception's what() string, which is
+// the difference between "abort() has been called" and knowing what threw.
+//
+// The modal abort dialog is suppressed — on a kiosk HMI a message box nobody
+// can click is a hang, not a diagnostic.
+
+namespace tfc {
+
+// Installs the handlers. |dump_dir| is where minidumps are written; pass the
+// directory containing the log file. Safe to call once, early in wWinMain,
+// after stdio has been redirected so the records land in the log.
+void InstallCrashHandlers(const std::string& dump_dir);
+
+}  // namespace tfc
+
+#endif  // RUNNER_CRASH_HANDLER_H_

--- a/centroid-hmi/windows/runner/log_rotation.cpp
+++ b/centroid-hmi/windows/runner/log_rotation.cpp
@@ -1,0 +1,55 @@
+#include "log_rotation.h"
+
+namespace tfc {
+namespace {
+
+// Offset of the extension dot in |path|, or npos if the filename has none.
+// Only dots after the last path separator count — directories may contain dots
+// and inserting the generation there yields a path that does not exist.
+std::string::size_type ExtensionDot(const std::string& path) {
+  std::string::size_type slash = path.find_last_of("/\\");
+  std::string::size_type dot = path.find_last_of('.');
+  if (dot == std::string::npos) {
+    return std::string::npos;
+  }
+  if (slash != std::string::npos && dot < slash) {
+    return std::string::npos;
+  }
+  return dot;
+}
+
+}  // namespace
+
+std::string GenerationPath(const std::string& base, int generation) {
+  if (generation <= 0) {
+    return base;
+  }
+  const std::string suffix = "." + std::to_string(generation);
+  std::string::size_type dot = ExtensionDot(base);
+  if (dot == std::string::npos) {
+    return base + suffix;
+  }
+  return base.substr(0, dot) + suffix + base.substr(dot);
+}
+
+LogRotationPlan PlanRotation(const std::string& base, int max_archives) {
+  LogRotationPlan plan;
+
+  if (max_archives <= 0) {
+    plan.deletes.push_back(base);
+    return plan;
+  }
+
+  // The oldest generation has nowhere left to go.
+  plan.deletes.push_back(GenerationPath(base, max_archives));
+
+  // Walk downwards so each destination is free before it is written to.
+  for (int generation = max_archives - 1; generation >= 0; generation--) {
+    plan.renames.emplace_back(GenerationPath(base, generation),
+                              GenerationPath(base, generation + 1));
+  }
+
+  return plan;
+}
+
+}  // namespace tfc

--- a/centroid-hmi/windows/runner/log_rotation.h
+++ b/centroid-hmi/windows/runner/log_rotation.h
@@ -1,0 +1,41 @@
+#ifndef RUNNER_LOG_ROTATION_H_
+#define RUNNER_LOG_ROTATION_H_
+
+// Log file rotation planning.
+//
+// The runner writes its log to a fixed path so it can be found without knowing
+// where the app was launched from. That path has to be reused across runs,
+// which means the previous run's log — the interesting one, after a crash —
+// must be moved aside rather than truncated.
+//
+// The plan is computed here as pure data, with no filesystem access, so the
+// rename ordering can be unit tested. Getting that order wrong silently
+// collapses every generation into one file, which is invisible until the day
+// you actually need the history.
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tfc {
+
+struct LogRotationPlan {
+  // Files to remove, before any renames.
+  std::vector<std::string> deletes;
+
+  // Renames to perform, in the given order.
+  std::vector<std::pair<std::string, std::string>> renames;
+};
+
+// Path of archive generation |generation| of |base|. Generation 0 is |base|
+// itself. The number is inserted before the extension ("hmi.log" -> "hmi.1.log")
+// so archives keep the .log extension.
+std::string GenerationPath(const std::string& base, int generation);
+
+// Plan a rotation of |base| keeping |max_archives| previous generations.
+// max_archives <= 0 means keep nothing: the live file is simply deleted.
+LogRotationPlan PlanRotation(const std::string& base, int max_archives);
+
+}  // namespace tfc
+
+#endif  // RUNNER_LOG_ROTATION_H_

--- a/centroid-hmi/windows/runner/main.cpp
+++ b/centroid-hmi/windows/runner/main.cpp
@@ -3,15 +3,24 @@
 #include <windows.h>
 
 #include <cstdlib>
+#include <iostream>
+#include <string>
 
+#include "crash_handler.h"
 #include "flutter_window.h"
 #include "utils.h"
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
-  // Debug logging for MSIX/release builds:
-  //   CENTROID_STDOUT=1          → opens a console window with all output
-  //   CENTROID_LOG_FILE=<path>   → writes all output to a file
+  // Logging for MSIX/release builds:
+  //   CENTROID_STDOUT=1          → also opens a console window
+  //   CENTROID_LOG_FILE=<path>   → overrides the default log file location
+  //   CENTROID_LOG_ARCHIVES=<n>  → previous runs to keep (default 5)
+  //
+  // A log file is written unconditionally. This is a windowed app: with no
+  // console attached and no file, everything on stdout/stderr — including the
+  // crash records installed below — is discarded, which is exactly how a
+  // crash ends up with nothing to go on.
   char* debug_env = nullptr;
   size_t debug_env_len = 0;
   _dupenv_s(&debug_env, &debug_env_len, "CENTROID_STDOUT");
@@ -20,26 +29,52 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   size_t log_file_env_len = 0;
   _dupenv_s(&log_file_env, &log_file_env_len, "CENTROID_LOG_FILE");
 
+  char* archives_env = nullptr;
+  size_t archives_env_len = 0;
+  _dupenv_s(&archives_env, &archives_env_len, "CENTROID_LOG_ARCHIVES");
+
   bool debug_mode = debug_env != nullptr &&
                     (strcmp(debug_env, "1") == 0 || strcmp(debug_env, "true") == 0);
 
-  if (log_file_env != nullptr && log_file_env[0] != '\0') {
-    RedirectIOToFile(log_file_env);
-  } else if (debug_mode) {
+  int max_archives = 5;
+  if (archives_env != nullptr && archives_env[0] != '\0') {
+    int parsed = atoi(archives_env);
+    if (parsed >= 0) {
+      max_archives = parsed;
+    }
+  }
+
+  std::string log_path = (log_file_env != nullptr && log_file_env[0] != '\0')
+                             ? std::string(log_file_env)
+                             : DefaultLogPath();
+
+  // A console, when asked for or when launched from a terminal. Done first so
+  // the file redirect below wins for stdout/stderr.
+  if (debug_mode) {
     if (!::AttachConsole(ATTACH_PARENT_PROCESS)) {
       CreateAndAttachConsole();
     } else {
       RedirectIOToConsole();
     }
-  } else {
-    // Normal mode: console only from terminal or under debugger
-    if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {
-      CreateAndAttachConsole();
-    }
+  } else if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {
+    CreateAndAttachConsole();
+  }
+
+  if (!log_path.empty()) {
+    // Rotate before opening: RedirectIOToFile truncates, and the previous
+    // run's log is the one worth keeping after a crash.
+    RotateLogs(log_path, max_archives);
+    RedirectIOToFile(log_path.c_str());
+
+    // Only now can crash records actually be written somewhere.
+    tfc::InstallCrashHandlers(DirectoryOf(log_path));
+    std::cerr << "[startup] logging to " << log_path << " (keeping "
+              << max_archives << " previous runs)" << std::endl;
   }
 
   free(debug_env);
   free(log_file_env);
+  free(archives_env);
 
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.

--- a/centroid-hmi/windows/runner/test/CMakeLists.txt
+++ b/centroid-hmi/windows/runner/test/CMakeLists.txt
@@ -19,10 +19,19 @@ add_executable(gpu_watchdog_test
 )
 target_include_directories(gpu_watchdog_test PRIVATE "..")
 
-if(MSVC)
-  target_compile_options(gpu_watchdog_test PRIVATE /W4)
-else()
-  target_compile_options(gpu_watchdog_test PRIVATE -Wall -Wextra)
-endif()
+add_executable(log_rotation_test
+  "log_rotation_test.cpp"
+  "../log_rotation.cpp"
+)
+target_include_directories(log_rotation_test PRIVATE "..")
+
+foreach(target gpu_watchdog_test log_rotation_test)
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4)
+  else()
+    target_compile_options(${target} PRIVATE -Wall -Wextra)
+  endif()
+endforeach()
 
 add_test(NAME gpu_watchdog COMMAND gpu_watchdog_test)
+add_test(NAME log_rotation COMMAND log_rotation_test)

--- a/centroid-hmi/windows/runner/test/log_rotation_test.cpp
+++ b/centroid-hmi/windows/runner/test/log_rotation_test.cpp
@@ -1,0 +1,125 @@
+// Tests for log file rotation planning.
+//
+// Rotation is where post-mortem logs get silently destroyed: rename in the
+// wrong order and each generation overwrites the next, leaving one file. Since
+// the whole point of this code is to still have the log after a crash, the plan
+// is computed as pure data here and merely executed by the platform layer.
+
+#include "../log_rotation.h"
+
+#include "test_harness.h"
+
+#include <string>
+
+namespace {
+
+using tfc::LogRotationPlan;
+
+std::string Renames(const LogRotationPlan& plan) {
+  std::string out;
+  for (const auto& rename : plan.renames) {
+    if (!out.empty()) out += " ; ";
+    out += rename.first + " -> " + rename.second;
+  }
+  return out;
+}
+
+std::string Deletes(const LogRotationPlan& plan) {
+  std::string out;
+  for (const auto& path : plan.deletes) {
+    if (!out.empty()) out += " ; ";
+    out += path;
+  }
+  return out;
+}
+
+}  // namespace
+
+// --- Generation paths -------------------------------------------------------
+
+TEST(generation_zero_is_the_live_file) {
+  CHECK_EQ(tfc::GenerationPath("C:\\logs\\hmi.log", 0),
+           std::string("C:\\logs\\hmi.log"));
+}
+
+TEST(generation_number_goes_before_the_extension) {
+  // Keeps the .log extension so file associations and log viewers still work.
+  CHECK_EQ(tfc::GenerationPath("C:\\logs\\hmi.log", 1),
+           std::string("C:\\logs\\hmi.1.log"));
+  CHECK_EQ(tfc::GenerationPath("C:\\logs\\hmi.log", 12),
+           std::string("C:\\logs\\hmi.12.log"));
+}
+
+TEST(generation_path_handles_a_base_with_no_extension) {
+  CHECK_EQ(tfc::GenerationPath("hmi", 3), std::string("hmi.3"));
+}
+
+TEST(generation_path_ignores_dots_in_the_directory) {
+  // The naive "last dot in the string" search picks the directory's dot and
+  // produces C:\a.1.b\hmi.log — a path in a directory that does not exist.
+  CHECK_EQ(tfc::GenerationPath("C:\\a.b\\hmi.log", 1),
+           std::string("C:\\a.b\\hmi.1.log"));
+  CHECK_EQ(tfc::GenerationPath("C:\\a.b\\hmi", 1), std::string("C:\\a.b\\hmi.1"));
+}
+
+TEST(generation_path_accepts_forward_slashes) {
+  CHECK_EQ(tfc::GenerationPath("/var/log/hmi.log", 2),
+           std::string("/var/log/hmi.2.log"));
+}
+
+// --- Rotation plan ----------------------------------------------------------
+
+TEST(rotation_renames_oldest_first_so_nothing_is_clobbered) {
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", 3);
+
+  // Descending order is the whole point: renaming hmi.1 -> hmi.2 before
+  // hmi.2 -> hmi.3 would destroy generation 2.
+  CHECK_EQ(Renames(plan),
+           std::string("hmi.2.log -> hmi.3.log ; "
+                       "hmi.1.log -> hmi.2.log ; "
+                       "hmi.log -> hmi.1.log"));
+}
+
+TEST(rotation_drops_the_generation_that_falls_off_the_end) {
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", 3);
+
+  CHECK_EQ(Deletes(plan), std::string("hmi.3.log"));
+}
+
+TEST(keeping_one_archive_still_preserves_the_previous_run) {
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", 1);
+
+  CHECK_EQ(Deletes(plan), std::string("hmi.1.log"));
+  CHECK_EQ(Renames(plan), std::string("hmi.log -> hmi.1.log"));
+}
+
+TEST(keeping_no_archives_deletes_the_live_file_and_renames_nothing) {
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", 0);
+
+  CHECK_EQ(Deletes(plan), std::string("hmi.log"));
+  CHECK_EQ(Renames(plan), std::string(""));
+}
+
+TEST(a_negative_archive_count_is_treated_as_zero) {
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", -5);
+
+  CHECK_EQ(Deletes(plan), std::string("hmi.log"));
+  CHECK_EQ(Renames(plan), std::string(""));
+}
+
+TEST(every_renamed_generation_is_within_the_archive_limit) {
+  const int kMaxArchives = 4;
+  LogRotationPlan plan = tfc::PlanRotation("hmi.log", kMaxArchives);
+
+  // Nothing may be renamed to a generation above the limit, or rotation grows
+  // without bound and the disk fills — the exact failure this replaces.
+  for (const auto& rename : plan.renames) {
+    CHECK(rename.second != tfc::GenerationPath("hmi.log", kMaxArchives + 1));
+  }
+  CHECK_EQ(static_cast<int>(plan.renames.size()), kMaxArchives);
+}
+
+int main() {
+  std::printf("log_rotation_test\n");
+  return tfc_test::RunAll();
+}

--- a/centroid-hmi/windows/runner/utils.cpp
+++ b/centroid-hmi/windows/runner/utils.cpp
@@ -1,12 +1,16 @@
 #include "utils.h"
 
+#include "log_rotation.h"
+
 #include <flutter_windows.h>
 #include <fcntl.h>
 #include <io.h>
 #include <stdio.h>
 #include <windows.h>
 
+#include <cstdlib>  // free, _wdupenv_s
 #include <iostream>
+#include <string>
 #include <vector>
 
 void CreateAndAttachConsole() {
@@ -117,4 +121,77 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
     return std::string();
   }
   return utf8_string;
+}
+
+namespace {
+
+std::wstring Utf16FromUtf8(const std::string& utf8) {
+  if (utf8.empty()) return std::wstring();
+  int len = ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
+  if (len <= 0) return std::wstring();
+  std::wstring wide(static_cast<size_t>(len) - 1, L'\0');
+  ::MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &wide[0], len);
+  return wide;
+}
+
+std::string Utf8FromUtf16Str(const std::wstring& utf16) {
+  if (utf16.empty()) return std::string();
+  int len = ::WideCharToMultiByte(CP_UTF8, 0, utf16.c_str(), -1, nullptr, 0,
+                                  nullptr, nullptr);
+  if (len <= 0) return std::string();
+  std::string utf8(static_cast<size_t>(len) - 1, '\0');
+  ::WideCharToMultiByte(CP_UTF8, 0, utf16.c_str(), -1, &utf8[0], len, nullptr,
+                        nullptr);
+  return utf8;
+}
+
+}  // namespace
+
+std::string DirectoryOf(const std::string& path) {
+  std::string::size_type slash = path.find_last_of("/\\");
+  if (slash == std::string::npos) return std::string();
+  return path.substr(0, slash);
+}
+
+std::string DefaultLogPath() {
+  wchar_t* local_app_data = nullptr;
+  size_t len = 0;
+  if (_wdupenv_s(&local_app_data, &len, L"LOCALAPPDATA") != 0 ||
+      local_app_data == nullptr) {
+    return std::string();
+  }
+  std::wstring dir(local_app_data);
+  free(local_app_data);
+
+  // CreateDirectoryW does not create intermediate levels, so build the two
+  // levels we need in order. Both may already exist; that is not an error.
+  dir += L"\\centroid-hmi";
+  ::CreateDirectoryW(dir.c_str(), nullptr);
+  dir += L"\\logs";
+  ::CreateDirectoryW(dir.c_str(), nullptr);
+
+  DWORD attributes = ::GetFileAttributesW(dir.c_str());
+  if (attributes == INVALID_FILE_ATTRIBUTES ||
+      !(attributes & FILE_ATTRIBUTE_DIRECTORY)) {
+    return std::string();
+  }
+
+  return Utf8FromUtf16Str(dir + L"\\hmi.log");
+}
+
+void RotateLogs(const std::string& path, int max_archives) {
+  if (path.empty()) return;
+
+  tfc::LogRotationPlan plan = tfc::PlanRotation(path, max_archives);
+
+  for (const std::string& doomed : plan.deletes) {
+    ::DeleteFileW(Utf16FromUtf8(doomed).c_str());
+  }
+  for (const auto& rename : plan.renames) {
+    // MOVEFILE_REPLACE_EXISTING for safety: a leftover destination from an
+    // interrupted rotation must not stop the chain.
+    ::MoveFileExW(Utf16FromUtf8(rename.first).c_str(),
+                  Utf16FromUtf8(rename.second).c_str(),
+                  MOVEFILE_REPLACE_EXISTING);
+  }
 }

--- a/centroid-hmi/windows/runner/utils.h
+++ b/centroid-hmi/windows/runner/utils.h
@@ -11,8 +11,26 @@ void CreateAndAttachConsole();
 // Redirects stdout and stderr to an already-attached console.
 void RedirectIOToConsole();
 
-// Redirects stdout and stderr to a log file.
+// Redirects stdout and stderr to a log file. Truncates |path|; call
+// RotateLogs first to keep the previous run.
 void RedirectIOToFile(const char* path);
+
+// Default log file location: %LOCALAPPDATA%\centroid-hmi\logs\hmi.log,
+// creating the directory. Returns an empty string if it cannot be created.
+//
+// Logging to a file by default is deliberate: this is a windowed app, so
+// without a console and without CENTROID_LOG_FILE set, everything written to
+// stdout/stderr — including crash records — goes nowhere at all.
+std::string DefaultLogPath();
+
+// Directory part of |path|, empty if it has none.
+std::string DirectoryOf(const std::string& path);
+
+// Moves previous runs aside so this run starts a fresh file, keeping
+// |max_archives| generations (hmi.1.log, hmi.2.log, ...). Without this the
+// log from the run that crashed is destroyed by the relaunch that goes
+// looking for it.
+void RotateLogs(const std::string& path, int max_archives);
 
 // Takes a null-terminated wchar_t* encoded in UTF-16 and returns a std::string
 // encoded in UTF-8. Returns an empty std::string on failure.


### PR DESCRIPTION
## Why

An `abort()` on the test rig produced nothing to go on. That was not one gap but three, and each on its own is enough to lose a crash.

**1. Logging was opt-in.** Without `CENTROID_LOG_FILE` or `CENTROID_STDOUT`, `main.cpp` attaches no console unless a debugger is present. A windowed app with no console and no file discards everything on stdout/stderr — including anything written on the way down.

**2. `RedirectIOToFile` used `CREATE_ALWAYS`.** It truncated on every launch. So even with logging switched on, the act of relaunching to investigate destroyed the log of the run that crashed. This one is quietly the worst of the three: it makes the log look like it never recorded anything.

**3. Nothing captured crashes.** `abort()`, an uncaught C++ exception, an exception escaping a `noexcept` function, an access violation, a CRT invalid parameter, and a pure virtual call all terminate the process without writing a word.

## What changes

A log file is now always written, defaulting to `%LOCALAPPDATA%\centroid-hmi\logs\hmi.log`. Previous runs rotate to `hmi.1.log` … `hmi.5.log` before the new one opens.

Crash handlers are installed immediately after the redirect — so they always have somewhere to write. Each writes a one-line record plus a minidump beside the log, then ends the process deterministically:

| Failure | Previously | Now |
|---|---|---|
| `abort()` | message box, nothing logged | `[crash] abort() thread=… detail=signal=22` + dump |
| uncaught exception / `noexcept` violation | "abort() has been called" | `[crash] std::terminate … uncaught <type>: <what()>` + dump |
| access violation | process vanishes | `[crash] structured exception code=0x… address=0x…` + dump |
| CRT invalid parameter | silent `abort()` | expression, function, file, line + dump |
| pure virtual call | silent `abort()` | `[crash] pure virtual call` + dump |

The terminate handler recovers the exception via `std::current_exception()` and rethrows it into a `try/catch` to get `typeid` and `what()`. That is precisely the difference between "abort() has been called" and knowing what threw.

The modal abort dialog is suppressed. On a kiosk HMI a message box nobody can click is a hang, not a diagnostic — and since we write our own minidump, WER's is redundant.

## Testing

Rotation planning is pure logic (`tfc::PlanRotation`) with no filesystem access, so the rename ordering is unit tested. That ordering is worth pinning: rename ascending instead of descending and every generation overwrites the next, leaving exactly one file — invisible until the day you need the history. There is a test for the directory-with-a-dot case too, where a naive "last dot in the string" search yields a path in a directory that does not exist.

11 tests, written before the implementation and mutation-checked (5/5 mutants caught, including the clobber-ordering one). They run in the existing `windows-runner-cpp-test` CI job on ubuntu and windows.

I also removed a `ShouldRotate` helper I had written and tested, once the design settled on rotate-once-per-run and it would have shipped as tested-but-unused API.

The five Windows-only files were type-checked against stub headers with faithful signatures (verified to catch an injected arity error), but as before **only CI's `flutter build windows --release` proves they really compile.**

## Note on scope

This makes a repeat of the `abort()` self-explaining; it does not fix whatever caused it. The `noexcept` hole I flagged in `FlutterWindow::MessageHandler` — where an engine restart runs inside a `noexcept` function with no way to report failure — is still open, as is the question of whether to default the GPU watchdog off until it is proven on the rig. Both are deliberately not in this PR.

## Trying it

Launch, then look in `%LOCALAPPDATA%\centroid-hmi\logs\`. The first line names the log path and archive count. `CENTROID_LOG_ARCHIVES=0` keeps none; `CENTROID_LOG_FILE` still overrides the location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
