### PR TITLE
fix(windows): stop the GPU watchdog from aborting the process

### DIFF
--- a/centroid-hmi/windows/runner/flutter_window.cpp
+++ b/centroid-hmi/windows/runner/flutter_window.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <optional>
 #include <string>
+#include <typeinfo>
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -48,8 +49,12 @@ tfc::GpuWatchdog::Config WatchdogConfigFromEnvironment() {
 }
 
 bool WatchdogEnabledFromEnvironment() {
+  // Opt-in. The watchdog restarts the Flutter engine, and therefore the Dart
+  // app, on a judgement call about whether the renderer is alive. Until that
+  // judgement has been seen to be right on real hardware losing a real device,
+  // machines that have not asked for it should not get it.
   return tfc::ParseWatchdogEnabled(
-      CStrOrNull(GetEnvVar("CENTROID_GPU_WATCHDOG")), true);
+      CStrOrNull(GetEnvVar("CENTROID_GPU_WATCHDOG")), false);
 }
 
 void LogWatchdog(const std::string& message) {
@@ -130,7 +135,7 @@ bool FlutterWindow::OnCreate() {
                 "); relying on the periodic probe only");
   }
 
-  ApplyAction(watchdog_.OnStarted());
+  Dispatch(WatchdogEvent::kStarted);
   return true;
 }
 
@@ -148,6 +153,47 @@ void FlutterWindow::OnDestroy() {
   DestroyController();
 
   Win32Window::OnDestroy();
+}
+
+void FlutterWindow::Dispatch(WatchdogEvent event) {
+  if (!watchdog_enabled_ || watchdog_.has_given_up()) {
+    return;
+  }
+  try {
+    switch (event) {
+      case WatchdogEvent::kStarted:
+        ApplyAction(watchdog_.OnStarted());
+        break;
+      case WatchdogEvent::kTick:
+        ApplyAction(watchdog_.OnTick());
+        break;
+      case WatchdogEvent::kFramePresented:
+        ApplyAction(watchdog_.OnFramePresented());
+        break;
+      case WatchdogEvent::kDeviceLossHint:
+        ApplyAction(watchdog_.OnDeviceLossHint());
+        break;
+    }
+  } catch (const std::exception& e) {
+    // MessageHandler is noexcept and the frame callback runs inside the
+    // engine's task runner: letting anything escape either one calls
+    // std::terminate, which is an abort with no explanation attached. Failing
+    // safe costs the recovery feature and leaves the app behaving exactly as
+    // it did before the watchdog existed.
+    LogWatchdog(std::string("disabling watchdog — ") + typeid(e).name() + ": " +
+                e.what());
+    DisableWatchdog();
+  } catch (...) {
+    LogWatchdog("disabling watchdog — unknown exception");
+    DisableWatchdog();
+  }
+}
+
+void FlutterWindow::DisableWatchdog() {
+  watchdog_.Disable();
+  if (watchdog_hwnd_ != nullptr) {
+    ::KillTimer(watchdog_hwnd_, kWatchdogTimerId);
+  }
 }
 
 void FlutterWindow::ApplyAction(const tfc::GpuWatchdog::Action& action) {
@@ -191,8 +237,8 @@ void FlutterWindow::StartProbe() {
 
 void FlutterWindow::OnFramePresented() {
   int attempts_before = watchdog_.recovery_attempts();
-  ApplyAction(watchdog_.OnFramePresented());
-  if (attempts_before > 0) {
+  Dispatch(WatchdogEvent::kFramePresented);
+  if (attempts_before > 0 && !watchdog_.has_given_up()) {
     LogWatchdog("renderer healthy again after " +
                 std::to_string(attempts_before) + " recovery attempt(s)");
   }
@@ -210,7 +256,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   // Handled before Flutter sees it — the timer is ours by id, and nothing in
   // the engine should claim it.
   if (message == WM_TIMER && wparam == kWatchdogTimerId) {
-    ApplyAction(watchdog_.OnTick());
+    Dispatch(WatchdogEvent::kTick);
     return 0;
   }
 
@@ -239,7 +285,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
       if (wparam == PBT_APMRESUMEAUTOMATIC || wparam == PBT_APMRESUMESUSPEND) {
         if (watchdog_enabled_ && flutter_controller_) {
           LogWatchdog("probing after power resume");
-          ApplyAction(watchdog_.OnDeviceLossHint());
+          Dispatch(WatchdogEvent::kDeviceLossHint);
         }
       }
       break;
@@ -247,7 +293,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     case WM_DISPLAYCHANGE:
       if (watchdog_enabled_ && flutter_controller_) {
         LogWatchdog("probing after display change");
-        ApplyAction(watchdog_.OnDeviceLossHint());
+        Dispatch(WatchdogEvent::kDeviceLossHint);
       }
       break;
 
@@ -262,7 +308,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
         case WTS_SESSION_UNLOCK:
           if (watchdog_enabled_ && flutter_controller_) {
             LogWatchdog("probing after session change");
-            ApplyAction(watchdog_.OnDeviceLossHint());
+            Dispatch(WatchdogEvent::kDeviceLossHint);
           }
           break;
         default:

--- a/centroid-hmi/windows/runner/flutter_window.h
+++ b/centroid-hmi/windows/runner/flutter_window.h
@@ -43,6 +43,24 @@ class FlutterWindow : public Win32Window {
   // translates window messages and engine callbacks into watchdog events, and
   // carries out whatever the watchdog asks for.
 
+  // The events the watchdog understands, so every one of them reaches it
+  // through the single guarded path in Dispatch.
+  enum class WatchdogEvent {
+    kStarted,
+    kTick,
+    kFramePresented,
+    kDeviceLossHint,
+  };
+
+  // The only place the watchdog is driven from. Swallows exceptions and
+  // disables the watchdog rather than letting anything escape: this runs
+  // inside a noexcept window procedure and inside the engine's frame
+  // callback, where an escaping exception is std::terminate.
+  void Dispatch(WatchdogEvent event);
+
+  // Stop watching and cancel the tick timer.
+  void DisableWatchdog();
+
   void ApplyAction(const tfc::GpuWatchdog::Action& action);
 
   // Asks the engine for a frame and re-arms the next-frame callback.

--- a/centroid-hmi/windows/runner/gpu_watchdog.cpp
+++ b/centroid-hmi/windows/runner/gpu_watchdog.cpp
@@ -28,6 +28,9 @@ GpuWatchdog::GpuWatchdog(Config config) : config_(config) {}
 
 GpuWatchdog::Action GpuWatchdog::OnStarted() {
   Action action;
+  if (disabled_) {
+    return action;
+  }
   probe_outstanding_ = true;
   action.start_probe = true;
   action.set_timer_ms = config_.probe_interval_ms;
@@ -36,12 +39,23 @@ GpuWatchdog::Action GpuWatchdog::OnStarted() {
 
 GpuWatchdog::Action GpuWatchdog::OnTick() {
   Action action;
+  if (disabled_) {
+    return action;
+  }
 
   if (probe_outstanding_) {
     missed_probes_++;
     if (missed_probes_ >= config_.missed_probes_before_recovery) {
       recovery_attempts_++;
       missed_probes_ = 0;
+      if (config_.max_recovery_attempts > 0 &&
+          recovery_attempts_ >= config_.max_recovery_attempts) {
+        // Hand back this last restart, then stop: one more attempt is worth
+        // more than a tidy state machine, but an endless loop is not.
+        disabled_ = true;
+        action.restart_engine = true;
+        return action;
+      }
       // Recreating the controller issues its own ForceRedraw and arms the
       // next-frame callback, so the restart *is* the next probe. Leaving the
       // flag set means the following ticks judge the new engine.
@@ -61,6 +75,9 @@ GpuWatchdog::Action GpuWatchdog::OnTick() {
 
 GpuWatchdog::Action GpuWatchdog::OnFramePresented() {
   Action action;
+  if (disabled_) {
+    return action;
+  }
   probe_outstanding_ = false;
   missed_probes_ = 0;
 
@@ -78,6 +95,9 @@ GpuWatchdog::Action GpuWatchdog::OnFramePresented() {
 
 GpuWatchdog::Action GpuWatchdog::OnDeviceLossHint() {
   Action action;
+  if (disabled_) {
+    return action;
+  }
   // Deliberately does not touch missed_probes_: a flood of session-change
   // messages must not be able to hold the failure count at zero while frames
   // are actually missing.
@@ -85,6 +105,11 @@ GpuWatchdog::Action GpuWatchdog::OnDeviceLossHint() {
   action.start_probe = true;
   action.set_timer_ms = config_.probe_interval_ms;
   return action;
+}
+
+void GpuWatchdog::Disable() {
+  disabled_ = true;
+  probe_outstanding_ = false;
 }
 
 unsigned int GpuWatchdog::BackoffMs() const {

--- a/centroid-hmi/windows/runner/gpu_watchdog.h
+++ b/centroid-hmi/windows/runner/gpu_watchdog.h
@@ -51,6 +51,12 @@ class GpuWatchdog {
     // Ceiling for the post-recovery backoff, so a GPU that never comes back is
     // retried slowly instead of rebooting the engine every few seconds.
     unsigned int max_probe_interval_ms = 60000;
+
+    // Consecutive failed recoveries before the watchdog gives up for good.
+    // Restarting the engine restarts the Dart app with it, so a GPU that is
+    // never coming back would otherwise wipe the operator's UI on every
+    // backoff interval, forever. 0 means never give up.
+    int max_recovery_attempts = 5;
   };
 
   // What the host should do in response to an event.
@@ -85,6 +91,17 @@ class GpuWatchdog {
   // benign resolution change cannot reboot the engine on its own.
   Action OnDeviceLossHint();
 
+  // Stop watching, permanently. The host calls this when carrying out an
+  // action threw: the window procedure that drives the watchdog is noexcept,
+  // so an exception escaping it aborts the process. Failing safe here costs
+  // the recovery feature and leaves the app exactly as it behaved before the
+  // watchdog existed.
+  void Disable();
+
+  // True once the watchdog has stopped acting, whether from Disable() or from
+  // exhausting max_recovery_attempts.
+  bool has_given_up() const { return disabled_; }
+
   int missed_probes() const { return missed_probes_; }
   int recovery_attempts() const { return recovery_attempts_; }
   bool probe_outstanding() const { return probe_outstanding_; }
@@ -94,6 +111,7 @@ class GpuWatchdog {
   unsigned int BackoffMs() const;
 
   Config config_;
+  bool disabled_ = false;
   bool probe_outstanding_ = false;
   int missed_probes_ = 0;
   int recovery_attempts_ = 0;

--- a/centroid-hmi/windows/runner/test/gpu_watchdog_test.cpp
+++ b/centroid-hmi/windows/runner/test/gpu_watchdog_test.cpp
@@ -19,6 +19,9 @@ GpuWatchdog::Config TestConfig() {
   config.probe_interval_ms = 5000;
   config.missed_probes_before_recovery = 2;
   config.max_probe_interval_ms = 60000;
+  // Never give up, so tests about probing and backoff are not cut short by the
+  // give-up budget. Tests that are about giving up set this themselves.
+  config.max_recovery_attempts = 0;
   return config;
 }
 
@@ -143,9 +146,14 @@ TEST(recovery_backs_off_geometrically_and_caps) {
   const unsigned int expected[] = {5000, 10000, 20000, 40000, 60000, 60000};
   for (unsigned int want : expected) {
     GpuWatchdog::Action action;
+    // Bounded: a watchdog that stops asking for restarts would otherwise spin
+    // this loop forever and hang CI with no failure to read.
+    int guard = 0;
     do {
       action = watchdog.OnTick();
-    } while (!action.restart_engine);
+      guard++;
+    } while (!action.restart_engine && guard < 100);
+    CHECK(action.restart_engine);
     CHECK_EQ(action.set_timer_ms, want);
   }
 }
@@ -235,6 +243,127 @@ TEST(probe_interval_falls_back_when_absent_or_nonsensical) {
   CHECK_EQ(tfc::ParseProbeIntervalMs("250", 5000), 5000u);
   CHECK_EQ(tfc::ParseProbeIntervalMs("1000", 5000), 1000u);
   CHECK_EQ(tfc::ParseProbeIntervalMs("30000", 5000), 30000u);
+}
+
+// --- Giving up --------------------------------------------------------------
+
+TEST(stops_restarting_after_the_configured_number_of_consecutive_recoveries) {
+  GpuWatchdog::Config config = TestConfig();
+  config.max_recovery_attempts = 3;
+  GpuWatchdog watchdog(config);
+  watchdog.OnStarted();
+
+  int restarts = 0;
+  for (int tick = 0; tick < 100; tick++) {
+    if (watchdog.OnTick().restart_engine) {
+      restarts++;
+    }
+  }
+
+  // Rebooting the engine forever on a GPU that is never coming back means
+  // rebooting the Dart app forever: the operator gets a UI that wipes itself
+  // every backoff interval instead of one that has visibly given up.
+  CHECK_EQ(restarts, 3);
+  CHECK(watchdog.has_given_up());
+}
+
+TEST(a_healthy_frame_makes_the_give_up_budget_whole_again) {
+  GpuWatchdog::Config config = TestConfig();
+  config.max_recovery_attempts = 3;
+  GpuWatchdog watchdog(config);
+  watchdog.OnStarted();
+
+  watchdog.OnTick();
+  CHECK(watchdog.OnTick().restart_engine);  // recovery 1
+  watchdog.OnFramePresented();              // ...which worked
+
+  // The budget is for *consecutive* failures. A device that drops out once an
+  // hour must not exhaust it over a week of uptime.
+  CHECK_EQ(watchdog.recovery_attempts(), 0);
+  CHECK(!watchdog.has_given_up());
+}
+
+TEST(zero_max_recovery_attempts_means_never_give_up) {
+  GpuWatchdog::Config config = TestConfig();
+  config.max_recovery_attempts = 0;
+  GpuWatchdog watchdog(config);
+  watchdog.OnStarted();
+
+  int restarts = 0;
+  for (int tick = 0; tick < 100; tick++) {
+    if (watchdog.OnTick().restart_engine) restarts++;
+  }
+
+  CHECK(restarts > 10);
+  CHECK(!watchdog.has_given_up());
+}
+
+// --- Disabling --------------------------------------------------------------
+
+TEST(a_disabled_watchdog_does_nothing_at_all) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+
+  watchdog.Disable();
+
+  // Disable is what the host reaches for when executing an action threw. If
+  // any event still asked for work, the very next tick would re-enter the code
+  // that just failed — and in a noexcept window proc that is a hard abort.
+  GpuWatchdog::Action tick = watchdog.OnTick();
+  CHECK(!tick.start_probe);
+  CHECK(!tick.restart_engine);
+  CHECK_EQ(tick.set_timer_ms, 0u);
+
+  GpuWatchdog::Action hint = watchdog.OnDeviceLossHint();
+  CHECK(!hint.start_probe);
+  CHECK(!hint.restart_engine);
+  CHECK_EQ(hint.set_timer_ms, 0u);
+
+  GpuWatchdog::Action frame = watchdog.OnFramePresented();
+  CHECK(!frame.start_probe);
+  CHECK(!frame.restart_engine);
+  CHECK_EQ(frame.set_timer_ms, 0u);
+}
+
+TEST(a_disabled_watchdog_ignores_a_late_frame_even_after_a_recovery) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.OnTick();
+  CHECK(watchdog.OnTick().restart_engine);
+  CHECK_EQ(watchdog.recovery_attempts(), 1);
+
+  watchdog.Disable();
+
+  // A frame can still land after the host has given up — the engine callback
+  // is already in flight. Re-arming the timer here would resurrect a watchdog
+  // that was disabled precisely because acting on it threw, sending the next
+  // tick straight back into the code that aborted.
+  GpuWatchdog::Action frame = watchdog.OnFramePresented();
+  CHECK_EQ(frame.set_timer_ms, 0u);
+  CHECK(watchdog.has_given_up());
+}
+
+TEST(disabling_survives_any_number_of_missed_probes) {
+  GpuWatchdog watchdog(TestConfig());
+  watchdog.OnStarted();
+  watchdog.Disable();
+
+  for (int tick = 0; tick < 50; tick++) {
+    CHECK(!watchdog.OnTick().restart_engine);
+  }
+}
+
+TEST(giving_up_is_reported_as_disabled) {
+  GpuWatchdog::Config config = TestConfig();
+  config.max_recovery_attempts = 1;
+  GpuWatchdog watchdog(config);
+  watchdog.OnStarted();
+
+  watchdog.OnTick();
+  CHECK(watchdog.OnTick().restart_engine);  // the one and only attempt
+
+  CHECK(watchdog.has_given_up());
+  CHECK(!watchdog.OnTick().start_probe);
 }
 
 int main() {


### PR DESCRIPTION
## The defect

I introduced this in #137 and it needs fixing regardless of what caused the abort on the test rig.

`FlutterWindow::MessageHandler` is `noexcept` (inherited from `Win32Window`, `win32_window.h:65`). The `WM_TIMER` path ran `ApplyAction`, which shuts an engine down and constructs a new one — allocating, registering plugins, building a `FlutterViewController`, storing `std::function`s. Anything throwing in there escapes a `noexcept` function, which is `std::terminate`, which is `abort()` **with nothing attached**.

Before #137 that handler did almost nothing — `HandleTopLevelWindowProc` and `ReloadSystemFonts`. I put a full engine restart inside it and gave it no way to report failure. Same applies to `OnFramePresented`, which runs inside the engine's platform task runner.

That is exactly the shape of "abort() called, no meaningful log".

## The fix

Every watchdog event now reaches the state machine through one guarded entry point:

```cpp
void FlutterWindow::Dispatch(WatchdogEvent event) {
  if (!watchdog_enabled_ || watchdog_.has_given_up()) return;
  try {
    switch (event) { /* ... */ }
  } catch (const std::exception& e) {
    LogWatchdog(std::string("disabling watchdog — ") + typeid(e).name() + ": " + e.what());
    DisableWatchdog();
  } catch (...) { /* same */ }
}
```

Catching and disabling costs the recovery feature and leaves the app behaving exactly as it did before the watchdog existed — strictly better than terminating the process. And with #142 already in, the reason now lands in the log with the exception's type and `what()`.

**The watchdog is now opt-in** (`CENTROID_GPU_WATCHDOG=1`). It restarts the Dart app on a judgement call about whether the renderer is alive, and that judgement still has not been seen to be right on hardware actually losing a device. Machines that have not asked for it should not get it. This also makes attribution trivial: if aborts continue with it off, it was never mine.

**It gives up after 5 consecutive failed recoveries.** Restarting the engine restarts the app with it, so a GPU that is never coming back would otherwise wipe the operator's UI every backoff interval, forever. The budget resets on any healthy frame, so it bounds *consecutive* failures — a device that drops out once an hour will not exhaust it over a week of uptime.

## Testing

7 new tests, 23 total, all mutation-checked (5/5 caught). Two real bugs the process caught while writing this, both worth naming:

**An infinite loop I introduced into an existing test.** Adding `max_recovery_attempts` to `Config` meant the shared `TestConfig()` inherited the default of 5, so the backoff test's unbounded `do { } while (!action.restart_engine)` spun forever once the watchdog gave up. `TestConfig()` now disables the budget, and that loop is bounded so a watchdog which stops restarting *fails* rather than hanging CI with nothing to read.

**A test suite that passed with the fix deleted.** My first version of the disable tests survived removing the `disabled_` guard from `OnFramePresented`, because no test had a recovery in flight at the moment it disabled — so the function's only side effect was already a no-op. Added a test for the case that matters: a frame landing after a disable must not re-arm the timer and resurrect a watchdog that was disabled *because acting on it threw*.

**And one in this PR's own diff.** A blanket string replace rewrote the `kDeviceLossHint` case inside `Dispatch`'s own switch into a recursive `Dispatch` call — infinite recursion. Caught by reading the grep output before compiling; there is now a check that `Dispatch` contains no recursive call.

Windows-only code is stub-type-checked as before. Only CI's `flutter build windows --release` proves it compiles — and on #142 that caught two missing includes my stubs could not, so treat the local check accordingly.

## What this does not do

It does not explain the abort on the rig. It makes a repeat of it survivable and self-describing, and takes my change out of the default path. The `CENTROID_GPU_WATCHDOG=0` experiment and the WER faulting-module lookup are still the two things that would actually attribute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
