### PR TITLE
test: stop CI failing on rendering drift and a slow Windows stub start

### DIFF
--- a/packages/tfc_dart/test/core/umas_fb_visibility_test.dart
+++ b/packages/tfc_dart/test/core/umas_fb_visibility_test.dart
@@ -91,7 +91,7 @@ Future<void> _startStub() async {
     }
   });
 
-  _stubPort = await completer.future.timeout(const Duration(seconds: 5),
+  _stubPort = await completer.future.timeout(const Duration(seconds: 30),
       onTimeout: () => throw StateError(
           'Stub server did not start (python=$python, '
           'script=$stubScript, stderr=$stderrBuf)'));

--- a/packages/tfc_dart/test/umas_browse_speculative_array_expand_test.dart
+++ b/packages/tfc_dart/test/umas_browse_speculative_array_expand_test.dart
@@ -89,7 +89,7 @@ Future<void> _startStub() async {
       }
     }
   });
-  _stubPort = await completer.future.timeout(const Duration(seconds: 5),
+  _stubPort = await completer.future.timeout(const Duration(seconds: 30),
       onTimeout: () => throw StateError(
           'Stub server did not start (python=$python, '
           'script=$stubScript, stderr=$stderrBuf)'));

--- a/packages/tfc_dart/test/umas_coils_registers_test.dart
+++ b/packages/tfc_dart/test/umas_coils_registers_test.dart
@@ -437,7 +437,7 @@ void main() {
       });
 
       stubPort = await completer.future.timeout(
-        const Duration(seconds: 10),
+        const Duration(seconds: 30),
         onTimeout: () => throw StateError('Stub server did not start'),
       );
     });

--- a/packages/tfc_dart/test/umas_diagnostics_e2e_test.dart
+++ b/packages/tfc_dart/test/umas_diagnostics_e2e_test.dart
@@ -80,7 +80,7 @@ Future<void> _startStub() async {
     }
   });
 
-  _stubPort = await completer.future.timeout(const Duration(seconds: 5),
+  _stubPort = await completer.future.timeout(const Duration(seconds: 30),
       onTimeout: () => throw StateError(
           'Stub server did not start (python=$python, '
           'script=$stubScript, stderr=$stderrBuf)'));

--- a/packages/tfc_dart/test/umas_e2e_test.dart
+++ b/packages/tfc_dart/test/umas_e2e_test.dart
@@ -81,7 +81,7 @@ Future<void> _startStub() async {
     }
   });
 
-  _stubPort = await completer.future.timeout(const Duration(seconds: 5),
+  _stubPort = await completer.future.timeout(const Duration(seconds: 30),
       onTimeout: () => throw StateError(
           'Stub server did not start (python=$python, '
           'script=$stubScript, stderr=$stderrBuf)'));

--- a/packages/tfc_dart/test/umas_monitor_plc_test.dart
+++ b/packages/tfc_dart/test/umas_monitor_plc_test.dart
@@ -873,7 +873,7 @@ void main() {
       });
 
       stubPort = await completer.future.timeout(
-        const Duration(seconds: 10),
+        const Duration(seconds: 30),
         onTimeout: () => throw StateError('Stub server did not start'),
       );
     }
@@ -1024,7 +1024,7 @@ void main() {
       });
 
       stubPort = await completer.future.timeout(
-        const Duration(seconds: 10),
+        const Duration(seconds: 30),
         onTimeout: () => throw StateError('M580 stub server did not start'),
       );
     }

--- a/packages/tfc_dart/test/umas_reservation_test.dart
+++ b/packages/tfc_dart/test/umas_reservation_test.dart
@@ -73,7 +73,7 @@ Future<void> _startStub() async {
     }
   });
 
-  _stubPort = await completer.future.timeout(const Duration(seconds: 5),
+  _stubPort = await completer.future.timeout(const Duration(seconds: 30),
       onTimeout: () => throw StateError(
           'Stub server did not start (python=$python, '
           'script=$stubScript, stderr=$stderrBuf)'));

--- a/packages/tfc_dart/test/umas_write_variable_test.dart
+++ b/packages/tfc_dart/test/umas_write_variable_test.dart
@@ -599,7 +599,7 @@ void main() {
       });
 
       stubPort = await completer.future.timeout(
-        const Duration(seconds: 10),
+        const Duration(seconds: 30),
         onTimeout: () => throw StateError('Stub server did not start'),
       );
     });

--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,0 +1,11 @@
+import 'dart:async';
+
+import 'helpers/golden_tolerance.dart';
+
+/// Applies to every test under `test/` except `test/widgets/`, which has its
+/// own config (Flutter uses the nearest one, not all of them — so that file
+/// calls [useTolerantGoldenComparator] as well).
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  useTolerantGoldenComparator();
+  await testMain();
+}

--- a/test/helpers/golden_tolerance.dart
+++ b/test/helpers/golden_tolerance.dart
@@ -1,0 +1,80 @@
+/// Golden comparison that tolerates a hair of pixel drift.
+///
+/// Goldens in this repo are generated on a developer's Mac and verified on a
+/// CI Mac (`skip: !Platform.isMacOS`), and the two do not run the same Flutter
+/// — CI pins a version in `.github/workflows/test.yml` while developers are on
+/// whatever they installed. Different Flutter versions rasterise the same
+/// drawing very slightly differently, so an exact byte comparison eventually
+/// fails on an image nobody touched: `third_party_speedBatcher_populated.png`
+/// went red at 10 differing pixels out of 356,700 — 0.0028% — with no change
+/// to the painter behind it.
+///
+/// The tolerance below is chosen against that number: loose enough to absorb
+/// antialiasing drift along a few edges, tight enough that a real regression
+/// still fails. These goldens are line drawings of machines; moving, resizing
+/// or dropping any part of one shifts thousands of pixels, orders of magnitude
+/// past the threshold.
+///
+/// This does not paper over a mismatch that matters. If a golden fails here,
+/// it changed by more than a rendering rounding error.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fraction of pixels allowed to differ before a golden is called a failure.
+///
+/// 0.01% — roughly 36 pixels on the smallest golden in the suite, about 3.5×
+/// the largest cross-version drift observed.
+const double kGoldenTolerance = 0.0001;
+
+/// Wraps the ambient [goldenFileComparator] so comparisons allow
+/// [kGoldenTolerance] drift.
+///
+/// Call from a `flutter_test_config.dart`, which runs after the test bootstrap
+/// has installed the per-suite [LocalFileComparator] — that comparator knows
+/// where the suite's `goldens/` directory is, and this preserves it.
+void useTolerantGoldenComparator({double tolerance = kGoldenTolerance}) {
+  final current = goldenFileComparator;
+  if (current is! LocalFileComparator) return;
+  goldenFileComparator = TolerantGoldenComparator(
+    // LocalFileComparator takes the test file and keeps its directory; handing
+    // back any file in the existing basedir reproduces the same basedir.
+    current.basedir.resolve('flutter_test_config.dart'),
+    tolerance: tolerance,
+  );
+}
+
+/// A [LocalFileComparator] that passes when at most [tolerance] of the pixels
+/// differ. Public so `golden_tolerance_test.dart` can exercise the threshold
+/// directly; production code should go through [useTolerantGoldenComparator].
+class TolerantGoldenComparator extends LocalFileComparator {
+  TolerantGoldenComparator(super.testFile, {required this.tolerance})
+      : assert(tolerance >= 0 && tolerance <= 1);
+
+  final double tolerance;
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    final result = await GoldenFileComparator.compareLists(
+      imageBytes,
+      await getGoldenBytes(golden),
+    );
+
+    if (result.passed || result.diffPercent <= tolerance) {
+      if (!result.passed) {
+        // Say so rather than passing in silence — a golden that keeps creeping
+        // towards the threshold is worth someone regenerating.
+        debugPrint('Golden "$golden" differs by '
+            '${(result.diffPercent * 100).toStringAsFixed(4)}%, within the '
+            '${(tolerance * 100).toStringAsFixed(4)}% tolerance — passing.');
+      }
+      result.dispose();
+      return true;
+    }
+
+    final error = await generateFailureOutput(result, golden, basedir);
+    result.dispose();
+    throw FlutterError(error);
+  }
+}

--- a/test/helpers/golden_tolerance_test.dart
+++ b/test/helpers/golden_tolerance_test.dart
@@ -1,0 +1,153 @@
+/// Tests for the tolerant golden comparator.
+///
+/// A comparator that can wave a mismatch through needs its own guard rail: if
+/// the threshold logic were inverted or the tolerance read as a percentage
+/// instead of a fraction, every golden in the repo would quietly stop
+/// catching anything and nothing else would notice.
+library;
+
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'golden_tolerance.dart';
+
+/// A [width]×[height] opaque white PNG with the first [differing] pixels
+/// turned black.
+Future<Uint8List> _png({
+  required int width,
+  required int height,
+  int differing = 0,
+}) async {
+  final pixels = Uint8List(width * height * 4);
+  for (var i = 0; i < width * height; i++) {
+    final o = i * 4;
+    final value = i < differing ? 0 : 255;
+    pixels[o] = value; // R
+    pixels[o + 1] = value; // G
+    pixels[o + 2] = value; // B
+    pixels[o + 3] = 255; // A
+  }
+
+  final buffer = await ui.ImmutableBuffer.fromUint8List(pixels);
+  final descriptor = ui.ImageDescriptor.raw(
+    buffer,
+    width: width,
+    height: height,
+    pixelFormat: ui.PixelFormat.rgba8888,
+  );
+  final codec = await descriptor.instantiateCodec();
+  final frame = await codec.getNextFrame();
+  final encoded = await frame.image.toByteData(format: ui.ImageByteFormat.png);
+  return encoded!.buffer.asUint8List();
+}
+
+/// A comparator whose "golden on disk" is [golden], so the tests supply the
+/// reference image rather than committing fixture PNGs.
+///
+/// [basedir] still has to be a real writable directory: on a mismatch the
+/// comparator asks Flutter to write the diff images out, and that path is
+/// worth exercising too.
+class _InMemoryComparator extends TolerantGoldenComparator {
+  _InMemoryComparator(this.golden,
+      {required super.tolerance, required Directory basedir})
+      : super(basedir.uri.resolve('test.dart'));
+
+  final Uint8List golden;
+
+  @override
+  Future<List<int>> getGoldenBytes(Uri golden) async => this.golden;
+}
+
+void main() {
+  // 100×100 = 10,000 pixels, so one pixel is exactly 0.01%.
+  const width = 100;
+  const height = 100;
+
+  late Uint8List reference;
+  late Directory workdir;
+
+  setUp(() async {
+    reference = await _png(width: width, height: height);
+    workdir = Directory.systemTemp.createTempSync('golden_tolerance_test');
+    addTearDown(() => workdir.deleteSync(recursive: true));
+  });
+
+  test('an identical image passes', () async {
+    final comparator =
+        _InMemoryComparator(reference, tolerance: 0.0, basedir: workdir);
+    expect(
+        await comparator.compare(reference, Uri.parse('golden.png')), isTrue);
+  });
+
+  test('a difference under the tolerance passes', () async {
+    // 5 pixels of 10,000 = 0.05%, inside a 0.1% tolerance.
+    final drifted = await _png(width: width, height: height, differing: 5);
+    final comparator =
+        _InMemoryComparator(reference, tolerance: 0.001, basedir: workdir);
+    expect(await comparator.compare(drifted, Uri.parse('golden.png')), isTrue);
+  });
+
+  test('a difference exactly at the tolerance passes', () async {
+    // 10 pixels of 10,000 = 0.1%.
+    final drifted = await _png(width: width, height: height, differing: 10);
+    final comparator =
+        _InMemoryComparator(reference, tolerance: 0.001, basedir: workdir);
+    expect(await comparator.compare(drifted, Uri.parse('golden.png')), isTrue);
+  });
+
+  test('a difference over the tolerance still fails', () async {
+    // 20 pixels of 10,000 = 0.2%, outside a 0.1% tolerance. This is the case
+    // that matters: the comparator must not become a rubber stamp.
+    final drifted = await _png(width: width, height: height, differing: 20);
+    final comparator =
+        _InMemoryComparator(reference, tolerance: 0.001, basedir: workdir);
+    await expectLater(
+      () => comparator.compare(drifted, Uri.parse('golden.png')),
+      throwsA(isA<FlutterError>()),
+    );
+  });
+
+  test('a wholly different image fails at the shipped tolerance', () async {
+    final black =
+        await _png(width: width, height: height, differing: width * height);
+    final comparator = _InMemoryComparator(reference,
+        tolerance: kGoldenTolerance, basedir: workdir);
+    await expectLater(
+      () => comparator.compare(black, Uri.parse('golden.png')),
+      throwsA(isA<FlutterError>()),
+    );
+  });
+
+  test('the shipped tolerance is small enough to be meaningful', () {
+    // Guards against someone "fixing" a failing golden by widening this until
+    // it passes. 0.01% is ~36 pixels on the smallest golden in the suite.
+    expect(kGoldenTolerance, lessThanOrEqualTo(0.0005));
+    expect(kGoldenTolerance, greaterThan(0));
+  });
+
+  test('flutter_test_config.dart installs it for the whole suite', () {
+    // The wiring is the part most likely to rot silently — a renamed config
+    // file or a nested one shadowing the root would leave goldens back on
+    // exact comparison with nothing to say so.
+    expect(goldenFileComparator, isA<TolerantGoldenComparator>());
+    expect((goldenFileComparator as TolerantGoldenComparator).tolerance,
+        kGoldenTolerance);
+  });
+
+  test('useTolerantGoldenComparator keeps the suite golden directory',
+      () async {
+    final original = goldenFileComparator;
+    addTearDown(() => goldenFileComparator = original);
+
+    final before = (original as LocalFileComparator).basedir;
+    useTolerantGoldenComparator();
+
+    expect(goldenFileComparator, isA<TolerantGoldenComparator>());
+    expect((goldenFileComparator as LocalFileComparator).basedir, before,
+        reason:
+            'a different basedir would look for goldens in the wrong place');
+  });
+}

--- a/test/widgets/flutter_test_config.dart
+++ b/test/widgets/flutter_test_config.dart
@@ -4,9 +4,17 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/golden_tolerance.dart';
+
 /// Loads a real font so golden tests render readable text instead of Ahem blocks.
+///
+/// Flutter uses only the nearest `flutter_test_config.dart`, so this shadows
+/// `test/flutter_test_config.dart` for everything under `test/widgets/` and
+/// has to repeat its golden-tolerance setup.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  useTolerantGoldenComparator();
 
   final fontFile = File('lib/fonts/roboto-mono/RobotoMono-Regular.ttf');
   final fontData = fontFile.readAsBytesSync();


### PR DESCRIPTION
Two jobs have been red on `main` for a while, and neither is about the code they're testing. Both make every PR look broken.

## `flutter-test (macos-latest)` — golden drift

`third_party_speedBatcher_populated.png` fails at **10 differing pixels out of 356,700 — 0.0028%** — with nothing changed behind it. It passes locally.

The cause is an environment split. Goldens are generated on a developer's Mac and verified on a CI Mac (`skip: !Platform.isMacOS`), but the two aren't on the same Flutter: CI pins `3.44.9` in `test.yml`, developers are on whatever they installed (mine is `3.41.9`). Different versions rasterise the same drawing a shade differently, so an exact byte comparison eventually fails on an image nobody touched.

Golden comparison now tolerates **0.01%** of pixels differing — about 36 pixels on the smallest golden in the suite, roughly 3.5× the observed drift, and orders of magnitude below a real regression: these are line drawings of machines, and moving, resizing or dropping any part of one shifts thousands of pixels. It's the recipe from the `goldenFileComparator` docs, wired in via `flutter_test_config.dart`. When it lets a difference through it says so, so a golden creeping towards the threshold stays visible.

A comparator that can wave a mismatch through needs its own guard rail, so it has tests: under, at and over the threshold; a wholly different image at the shipped tolerance; that the tolerance stays small; and that `flutter_test_config.dart` actually installs it. That last one is the important one — the wiring is what rots silently, and since Flutter uses only the *nearest* config, the one under `test/widgets/` has to repeat the setup and now does.

## `tfc-dart-test (windows-latest)` — stub server race

```
Bad state: Stub server did not start (python=python3, script=...\test\umas_stub_server.py, stderr=)
```

The UMAS stub is a Python process given **5 seconds** to print its port. Empty stderr and a clean exit say it started fine and just hadn't got there yet — on a Windows runner spinning several up at once, whichever suite loses the race fails in `setUpAll`. The other seven stub-backed suites passed in the same run, which is what a race looks like rather than a broken interpreter.

Raised to 30 seconds across all eight launchers. A timeout that only fires when something is genuinely wrong costs nothing when it isn't.

## Alternative worth considering

The golden drift could instead be fixed at the source by pinning CI and developers to the same Flutter version. That's a call for whoever owns the toolchain decision — this PR takes the version-agnostic route so nobody's local install has to change. The same split is what broke #146 (an API that changed shape between 3.41 and 3.44), so it may be worth settling either way.

## Testing

- `flutter test test/` — 2496 passing, 6 skipped, including the macOS goldens that fail in CI.
- `dart test` on the stub-backed UMAS suites in `packages/tfc_dart` — passing.
- `flutter analyze --fatal-infos` clean on every new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
